### PR TITLE
Handle relative includes, even in the base directory

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -495,6 +496,11 @@ func (p *Parser) ParseFile(filename string) (*Thrift, error) {
 	if p.Filesystem != nil {
 		r, err = p.Filesystem.Open(filename)
 	} else {
+		filename, err = filepath.Abs(filename)
+		if err != nil {
+			return nil, err
+		}
+		filename = filepath.Clean(filename)
 		r, err = os.Open(filename)
 	}
 	if err != nil {


### PR DESCRIPTION
Hi Samuel,

this commit allows to parse relative includes. Even ones like

```
include "../.../common/errorhandling.thrift"
```

Have fun,

Ingo
