### PR TITLE
Fix for ErrUnknownType within included files

### DIFF
--- a/generator/main.go
+++ b/generator/main.go
@@ -92,7 +92,7 @@ func main() {
 	}
 
 	p := &parser.Parser{}
-	th, err := p.ParseFile(filename)
+	th, err := p.ParseFile(filename, "")
 	if e, ok := err.(*parser.ErrSyntaxError); ok {
 		fmt.Printf("%s\n", e.Left)
 		fmt.Fprintf(os.Stderr, "%s\n", err.Error())

--- a/parser/types.go
+++ b/parser/types.go
@@ -8,6 +8,7 @@ type Type struct {
 	Name      string
 	KeyType   *Type // If map
 	ValueType *Type // If map or list
+	IncludeName string
 }
 
 type EnumValue struct {
@@ -18,6 +19,7 @@ type EnumValue struct {
 type Enum struct {
 	Name   string
 	Values map[string]*EnumValue
+	IncludeName string
 }
 
 type Constant struct {
@@ -37,6 +39,7 @@ type Field struct {
 type Struct struct {
 	Name   string
 	Fields []*Field
+	IncludeName string
 }
 
 type Method struct {


### PR DESCRIPTION
When a type is a defined and used in an include the generator will throw an ErrUnknownType since it will be looking for the type as the name defined in the include while the Thrift object has the types keyed off the include name + the name of the type. 

The error would show up with two files with a pattern such as...

base.thrift

```
typedef string UUID

struct Context {
   1: required UUID id,
   2: optional string data
}
```

someservice.thrift

```
include "base.thrift"
```

The error being {ErrUnknownType UUID} since the struct is stored as base.UUID. 

The solution I coded up stores the include name along with the type and first looks for the include name plus the type name before looking for the type name when the include name exists.  I think a better solution would be to bring the behavior of the generator in line with other thrift generators by using the namespace of the includes to form a proper import statement, but that is another discussion.
