### PR TITLE
Use lower case arguments inside Client methods to initialize requests.

### DIFF
--- a/generator/go.go
+++ b/generator/go.go
@@ -437,8 +437,7 @@ func (g *GoGenerator) writeService(out io.Writer, svc *parser.Service) error {
 		// Request
 		g.write(out, "\treq := &%s%sRequest{\n", svcName, methodName)
 		for _, arg := range method.Arguments {
-			argName := camelCase(arg.Name)
-			g.write(out, "\t\t%s: %s,\n", argName, argName)
+			g.write(out, "\t\t%s: %s,\n", camelCase(arg.Name), lowerCamelCase(arg.Name))
 		}
 		g.write(out, "\t}\n")
 


### PR DESCRIPTION
After #2a05ca in which function arguments were changed to lower case, variables used in client methods are still upper case.

Ex.  

```
func (s *EchoerThriftfaceClient) Echo(args *EchoArgs, reply *EchoReply) error {
    req := &EchoerThriftfaceEchoRequest{
        Args:  Args,   # should be args
        Reply: Reply, # should be reply
    }
    ...
}
```
