### PR TITLE
Add lexically last panic to CompactProtocol Reader methods

### DIFF
--- a/thrift/protocol_compact.go
+++ b/thrift/protocol_compact.go
@@ -121,6 +121,7 @@ func (p *compactProtocol) readVarint(r io.Reader) (int64, error) {
 			return val, ProtocolError{"CompactProtocol", "varint overflow on read"}
 		}
 	}
+	panic("unreachable code")
 }
 
 func (p *compactProtocol) readUvarint(r io.Reader) (uint64, error) {
@@ -143,6 +144,7 @@ func (p *compactProtocol) readUvarint(r io.Reader) (uint64, error) {
 			return val, ProtocolError{"CompactProtocol", "varint overflow on read"}
 		}
 	}
+	panic("unreachable code")
 }
 
 // Write a message header to the wire. Compact Protocol messages contain the


### PR DESCRIPTION
protocol_compact.go:104: function ends without a return statement
protocol_compact.go:126: function ends without a return statement

occurs when importing go-thrift using Go v1. https://travis-ci.org/dghubble/servlib/jobs/13244201 

Lexically last panics let tests pass for Go v1.
