### PR TITLE
Go RPC Style Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,43 @@ incompatibility is the net/rpc's use of ServiceName.Method for naming
 RPC methods. To get around this the Thrift ServerCodec prefixes method
 names with "Thrift".
 
+The standard Go net/rpc package is used to provide RPC. It supports RPC services which meed the following criteria
+
+* the method is exported.
+* the method has two arguments, both exported (or builtin) types.
+* the method's second argument is a pointer.
+* the method has return type error.
+
+so a service method must look like
+
+```go
+// Go RPC Style Method Signature
+func (t *T) MethodName(argType T1, replyType *T2) error
+```
+
+Simulated pointer value mutation allows results to be retrieved from the client's reply pointer after an RPC call is made. However, the Thrift protocol communicates with languages which do not offer simulated pointer manipulation and a struct/message
+to be sent in a request and response across the wire must be defined so that response from an RPC call contains the results.
+
+```
+// thriftfile.thrift
+service MyService {
+
+  MyReply Echo(
+    1: MyArgs argz
+  )
+  ...
+}
+```
+
+```python
+# Dynamic Language
+result = client.Echo(MyArgs("a"))
+```
+
+Does this mean the signature of the services you write must change? No. You may use the command line argument ```-go.rpcstyle=true```. In this mode, the go-thrift generator will accept a thrift interface definition like the one shown above, but produce client and service stubs that assume your service methods are implemented in the Go RPC style method signature. You can continue to use pointer mutation in Go and get explicit replies when using thrift clients in other languages.
+
+*Constraint*: State may not be passed in the replyType argument in Go. Remember, on the thrift interface for your service methods, the replyType is the type returned.
+
 ### Transport
 
 There are no specific transport "classes" as there are in most Thrift
@@ -81,6 +118,7 @@ How to use the generator:
       -go.binarystring=false: Always use string for binary instead of []byte
       -go.json.enumnum=false: For JSON marshal enums by number instead of name
       -go.pointers=false: Make all fields pointers
+      -go.rpcstyle=false: Generate Go RPC style service methods.
 
     $ generator cassandra.thrift $GOPATH/src/
 


### PR DESCRIPTION
Adds a -go.rpcstyle=true option which allows service interfaces such as 

```
type EchoArgs struct {
    Message string `thrift:"1,required" json:"Message"`
}

type EchoReply struct {
    Echo string `thrift:"1,required" json:"Echo"`
}

service EchoerThriftface {
    EchoReply Echo(
        1: EchoArgs args
    )
}
```

to be defined to expose an ordinary thrift service for communication while allowing the arguments and reply to be combined into arguments within the Go service definition so that a method signature of the form ```func (t *T) MethodName(argType T1, replyType *T2) error``` can be used. Modifies the replyType pointer value so Go services can depend on this as usual in net/rpc. There is a constraint that initial/default values may not be placed in the replyType when making RPC calls in Go as those values will be ignored.

Update README to describe usage.

This is a feature I find useful for writing services in a Go RPC style, but still exposing an ordinary (without pointer passing simulation) Thrift interface for communication with non-Go thrift clients. Feel free to take it if you like. Otherwise I'll maintain it on my fork for myself.

fixes #28 