### PR TITLE
add NewStruct() with default field values

### DIFF
--- a/generator/go.go
+++ b/generator/go.go
@@ -303,6 +303,21 @@ func (g *GoGenerator) writeStruct(out io.Writer, st *parser.Struct) error {
 	for _, field := range st.Fields {
 		g.write(out, "\t%s\n", g.formatField(field))
 	}
+	g.write(out, "}\n")
+
+	g.write(out, "\nfunc New%s() *%s {\n", structName, structName)
+	g.write(out, "\treturn &%s{", structName)
+	hasDefaults := false
+	for _, field := range st.Fields {
+		if field.Default != nil {
+			hasDefaults = true
+			g.write(out, "\n\t\t%s: %v,", field.Name, field.Default)
+		}
+	}
+	if hasDefaults {
+		g.write(out, "\n")
+	}
+	g.write(out, "\t}\n")
 	return g.write(out, "}\n")
 }
 


### PR DESCRIPTION
Thrift defines default values for a struct.  This patch adds in the generator a `NewStruct()` function which fills the default values for fields within a struct.

For instance, a `struct` in the `Hbase.thrift` file called `Mutation` has some fields with default values:

```
struct Mutation {                                                                                                                                                                                        
  1:bool isDelete = 0,
  2:Text column,
  3:Text value,
  4:bool writeToWAL = 1
}
```

The patch would generate the following:

```
type Mutation struct {
    IsDelete   bool   `thrift:"1,required" json:"isDelete"`
    Column     []byte `thrift:"2,required" json:"column"`
    Value      []byte `thrift:"3,required" json:"value"`
    WriteToWAL bool   `thrift:"4,required" json:"writeToWAL"`
}

func NewMutation() *Mutation {
    return &Mutation{
        isDelete:   0,
        writeToWAL: 1,
    }
}
```
