### PR TITLE
use bitset in the structMeta other than uint64

### DIFF
--- a/thrift/bitset.go
+++ b/thrift/bitset.go
@@ -1,0 +1,70 @@
+package thrift
+
+import "errors"
+
+const size = 64
+
+type bits uint64
+
+// BitSet is a set of bits that can be set, cleared and queried.
+type BitSet []bits
+
+func numChange(t interface{}) (uint64, error) {
+
+	switch t := t.(type) {
+	case int:
+		return uint64(t), nil
+	case uint:
+		return uint64(t), nil
+	case int8:
+		return uint64(t), nil
+	case int16:
+		return uint64(t), nil
+	case int32:
+		return uint64(t), nil
+	case int64:
+		return uint64(t), nil
+	case uint8:
+		return uint64(t), nil
+	case uint16:
+		return uint64(t), nil
+	case uint32:
+		return uint64(t), nil
+	case uint64:
+		return uint64(t), nil
+	}
+	return 0, errors.New("type error")
+}
+
+// Set ensures that the given bit is set in the BitSet.
+func (s *BitSet) Set(n interface{}) {
+	i, _ := numChange(n)
+	if len(*s) < int(i/size+1) {
+		r := make([]bits, i/size+1)
+		copy(r, *s)
+		*s = r
+	}
+	(*s)[i/size] |= 1 << (i % size)
+}
+
+// Clear ensures that the given bit is cleared (not set) in the BitSet.
+func (s *BitSet) Clear(n interface{}) {
+	i, _ := numChange(n)
+	if len(*s) >= int(i/size+1) {
+		(*s)[i/size] &^= 1 << (i % size)
+	}
+}
+
+// IsSet returns true if the given bit is set, false if it is cleared.
+func (s *BitSet) IsSet(n interface{}) bool {
+	i, _ := numChange(n)
+	return (*s)[i/size]&(1<<(i%size)) != 0
+}
+func (s *BitSet) IsEmpty() bool {
+	for _, val := range *s {
+		if val != 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/thrift/bitset_test.go
+++ b/thrift/bitset_test.go
@@ -1,0 +1,16 @@
+package thrift
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestBitSet(t *testing.T) {
+	s := new(BitSet)
+	s.Set(13)
+	s.Set(45)
+	s.Clear(13)
+	fmt.Printf("s.IsSet(13) = %t; s.IsSet(45) = %t; s.IsSet(30) = %t\n",
+		s.IsSet(13), s.IsSet(45), s.IsSet(30))
+	// Output: s.IsSet(13) = false; s.IsSet(45) = true; s.IsSet(30) = false
+}

--- a/thrift/decoder.go
+++ b/thrift/decoder.go
@@ -156,7 +156,8 @@ func (d *decoder) readValue(thriftType byte, rf reflect.Value) {
 			if !ok {
 				SkipValue(d.r, ftype)
 			} else {
-				req &= ^(uint64(1) << uint64(id))
+				req.Clear(id)
+				//req &= ^(uint64(1) << uint64(id))
 				fieldValue := v.Field(ef.i)
 				if ftype != ef.fieldType {
 					d.error(&UnsupportedValueError{Value: fieldValue, Str: "type mismatch"})
@@ -173,15 +174,25 @@ func (d *decoder) readValue(thriftType byte, rf reflect.Value) {
 			d.error(err)
 		}
 
-		if req != 0 {
-			for i := 0; req != 0; i, req = i+1, req>>1 {
-				if req&1 != 0 {
+		if !req.IsEmpty() {
+			for i := 0; !req.IsEmpty(); i++ {
+				if req.IsSet(i) {
 					d.error(&MissingRequiredField{
 						StructName: v.Type().Name(),
 						FieldName:  meta.fields[i].name,
 					})
 				}
+				req.Clear(i)
 			}
+			/*
+				for i := 0; req != 0; i, req = i+1, req>>1 {
+					if req&1 != 0 {
+						d.error(&MissingRequiredField{
+							StructName: v.Type().Name(),
+							FieldName:  meta.fields[i].name,
+						})
+					}
+				}*/
 		}
 	case TypeMap:
 		keyType := v.Type().Key()

--- a/thrift/thrift.go
+++ b/thrift/thrift.go
@@ -191,7 +191,7 @@ type encodeField struct {
 }
 
 type structMeta struct {
-	required uint64 // bitmap of required fields
+	required *BitSet // bitmap of required fields
 	fields   map[int]encodeField
 }
 
@@ -219,6 +219,7 @@ func encodeFields(t reflect.Type) structMeta {
 
 	fs := make(map[int]encodeField)
 	m = structMeta{fields: fs}
+	m.required = new(BitSet)
 	v := reflect.Zero(t)
 	n := v.NumField()
 	for i := 0; i < n; i++ {
@@ -241,15 +242,17 @@ func encodeFields(t reflect.Type) structMeta {
 				continue
 			}
 			id, opts := parseTag(tv)
-			if id >= 64 {
-				// TODO: figure out a better way to deal with this
-				panic("thrift: field id must be < 64")
-			}
+			//if id >= 64 {
+			// TODO: figure out a better way to deal with this
+			//panic("thrift: field id must be < 64")
+			//	continue
+			//}
 			ef.id = id
 			ef.name = f.Name
 			ef.required = opts.Contains("required")
 			if ef.required {
-				m.required |= 1 << byte(id)
+				m.required.Set(id)
+				//m.required |= 1 << byte(id)
 			}
 			ef.keepEmpty = opts.Contains("keepempty")
 			if opts.Contains("set") {


### PR DESCRIPTION
But in the my project.The number of one struct fields is 103 , larger than 64.So I think using a bitset struct in structMeta other than uint64 may be better.