### PR TITLE
No need to check os.IsExist after os.MkdirAll.

### DIFF
--- a/generator/go.go
+++ b/generator/go.go
@@ -689,7 +689,7 @@ func (g *GoGenerator) Generate(outPath string) (err error) {
 		pkgpath := filepath.Join(outPath, pkg.Path, pkg.Name)
 		outfile := filepath.Join(pkgpath, filename)
 
-		if err := os.MkdirAll(pkgpath, 0755); err != nil && !os.IsExist(err) {
+		if err := os.MkdirAll(pkgpath, 0755); err != nil {
 			g.error(err)
 		}
 


### PR DESCRIPTION
`os.MkdirAll` safely handles the case where the path already exists.