### PR TITLE
Support formatting parser.Identifier values.

### DIFF
--- a/generator/go.go
+++ b/generator/go.go
@@ -298,6 +298,8 @@ func (g *GoGenerator) formatValue(v interface{}, t *parser.Type) (string, error)
 		}
 		buf.WriteString("\t}")
 		return buf.String(), nil
+	case parser.Identifier:
+		return string(v2), nil
 	}
 	return "", fmt.Errorf("unsupported value type %T", v)
 }


### PR DESCRIPTION
The switch statement's type assertion doesn't classify `parser.Identifier` as a
string so this case needs to be specifically handled. Otherwise, the generator
panics with:

    unsupported value type parser.Identifier

Also, `parser.Identifier` strings shouldn't be quoted.