### PR TITLE
Generate correct output for set<> constants.

### DIFF
--- a/generator/go.go
+++ b/generator/go.go
@@ -273,6 +273,9 @@ func (g *GoGenerator) formatValue(v interface{}, t *parser.Type) (string, error)
 				return "", err
 			}
 			buf.WriteString(s)
+			if t.Name == "set" {
+				buf.WriteString(": struct{}{}")
+			}
 			buf.WriteString(",\n")
 		}
 		buf.WriteString("\t}")


### PR DESCRIPTION
The parser models sets as arrays of values, but we represent sets using maps
in the generated code. The previous code wasn't writing the value portion of
the map items, resulting in "missing key in map literal" compilation errors.