### PR TITLE
Write set constants using 'var' instead of 'const'

### DIFF
--- a/generator/go.go
+++ b/generator/go.go
@@ -604,7 +604,7 @@ func (g *GoGenerator) generateSingle(out io.Writer, thriftPath string, thrift *p
 			if err != nil {
 				g.error(err)
 			}
-			if c.Type.Name == "list" || c.Type.Name == "map" {
+			if c.Type.Name == "list" || c.Type.Name == "map" || c.Type.Name == "set" {
 				g.write(out, "var ")
 			} else {
 				g.write(out, "const ")


### PR DESCRIPTION
We represent set constants using maps, which aren't constant literals.