### PR TITLE
Fix handling of constants with values that are other constant identifiers

### DIFF
--- a/generator/go.go
+++ b/generator/go.go
@@ -606,6 +606,12 @@ func (g *GoGenerator) generateSingle(out io.Writer, thriftPath string, thrift *p
 			if err != nil {
 				g.error(err)
 			}
+			// If a constant value is an identifier, it must be to another constant
+			// which we format using camelCase.
+			if identifier, ok := c.Value.(parser.Identifier); ok {
+				v = camelCase(string(identifier))
+			}
+
 			if c.Type.Name == "list" || c.Type.Name == "map" || c.Type.Name == "set" {
 				g.write(out, "var ")
 			} else {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -167,6 +167,33 @@ func TestServiceParsing(t *testing.T) {
 	}
 }
 
+func TestParseConstant(t *testing.T) {
+	parser := &Parser{}
+	thrift, err := parser.Parse(bytes.NewBuffer([]byte(`
+		const string C1 = "test"
+		const string C2 = C1
+		`)))
+	if err != nil {
+		t.Fatalf("Service parsing failed with error %s", err.Error())
+	}
+
+	expected := map[string]*Constant{
+		"C1": &Constant{
+			Name:  "C1",
+			Type:  &Type{Name: "string"},
+			Value: "test",
+		},
+		"C2": &Constant{
+			Name:  "C2",
+			Type:  &Type{Name: "string"},
+			Value: Identifier("C1"),
+		},
+	}
+	if got := thrift.Constants; !reflect.DeepEqual(expected, got) {
+		t.Errorf("Unexpected constant parsing got\n%s\ninstead of\n%s", pprint(expected), pprint(got))
+	}
+}
+
 // func TestParseFile(t *testing.T) {
 // 	th, err := ParseFile("../testfiles/full.thrift")
 // 	if err != nil {


### PR DESCRIPTION
 - Also add a test to ensure constants are parsed correctly

This fixes handling of:
```thrift
const string MY_CONST = "1"
const string SECOND_CONST = MY_CONST
const string THIRD_CONST = SECOND_CONST
```

This was previously generating:
```go
const MyConst = "1"
const SecondConst = MY_CONST
const ThirdConst = SECOND_CONST
```
Which is incorrect since `MY_CONST` and `SECOND_CONST` do not exist.

It now correctly generates:
```go
const MyConst = "1"
const SecondConst = MyConst
const ThirdConst = SecondConst
```