### PR TITLE
Generated nested struct fields correctly

### DIFF
--- a/generator/go.go
+++ b/generator/go.go
@@ -192,7 +192,7 @@ func (g *GoGenerator) formatType(pkg string, thrift *parser.Thrift, typ *parser.
 		return ptr + name
 	}
 	if s := thrift.Structs[typ.Name]; s != nil {
-		name := s.Name
+		name := camelCase(s.Name)
 		if pkg != g.pkg {
 			name = pkg + "." + name
 		}


### PR DESCRIPTION
Non-camel case structs generate invalid code:

```thrift
struct RGB {
    1: i32 red,
    2: i32 green,
    3: i32 blue,
}

struct NestedColor {
    1: RGB rgb,
}
```