### PR TITLE
Support newline after enum name, add test.

### DIFF
--- a/parser/grammar.peg
+++ b/parser/grammar.peg
@@ -120,7 +120,7 @@ Const ← "const" _ typ:FieldType _ name:Identifier _ "=" _ value:ConstValue EOS
 	}, nil
 }
 
-Enum ← "enum" _ name:Identifier _ '{' __ values:(EnumValue __)* '}' EOS {
+Enum ← "enum" _ name:Identifier __ '{' __ values:(EnumValue __)* '}' EOS {
 	vs := toIfaceSlice(values)
 	en := &Enum{
 		Name: string(name.(Identifier)),

--- a/parser/grammar.peg.go
+++ b/parser/grammar.peg.go
@@ -346,31 +346,31 @@ var g = &grammar{
 						},
 						&ruleRefExpr{
 							pos:  position{line: 123, col: 33, offset: 2646},
-							name: "_",
+							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 123, col: 35, offset: 2648},
+							pos:        position{line: 123, col: 36, offset: 2649},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 123, col: 39, offset: 2652},
+							pos:  position{line: 123, col: 40, offset: 2653},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 123, col: 42, offset: 2655},
+							pos:   position{line: 123, col: 43, offset: 2656},
 							label: "values",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 123, col: 49, offset: 2662},
+								pos: position{line: 123, col: 50, offset: 2663},
 								expr: &seqExpr{
-									pos: position{line: 123, col: 50, offset: 2663},
+									pos: position{line: 123, col: 51, offset: 2664},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 123, col: 50, offset: 2663},
+											pos:  position{line: 123, col: 51, offset: 2664},
 											name: "EnumValue",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 123, col: 60, offset: 2673},
+											pos:  position{line: 123, col: 61, offset: 2674},
 											name: "__",
 										},
 									},
@@ -378,12 +378,12 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 123, col: 65, offset: 2678},
+							pos:        position{line: 123, col: 66, offset: 2679},
 							val:        "}",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 123, col: 69, offset: 2682},
+							pos:  position{line: 123, col: 70, offset: 2683},
 							name: "EOS",
 						},
 					},
@@ -392,44 +392,44 @@ var g = &grammar{
 		},
 		{
 			name: "EnumValue",
-			pos:  position{line: 146, col: 1, offset: 3198},
+			pos:  position{line: 146, col: 1, offset: 3199},
 			expr: &actionExpr{
-				pos: position{line: 146, col: 13, offset: 3212},
+				pos: position{line: 146, col: 13, offset: 3213},
 				run: (*parser).callonEnumValue1,
 				expr: &seqExpr{
-					pos: position{line: 146, col: 13, offset: 3212},
+					pos: position{line: 146, col: 13, offset: 3213},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 146, col: 13, offset: 3212},
+							pos:   position{line: 146, col: 13, offset: 3213},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 146, col: 18, offset: 3217},
+								pos:  position{line: 146, col: 18, offset: 3218},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 146, col: 29, offset: 3228},
+							pos:  position{line: 146, col: 29, offset: 3229},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 146, col: 31, offset: 3230},
+							pos:   position{line: 146, col: 31, offset: 3231},
 							label: "value",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 146, col: 37, offset: 3236},
+								pos: position{line: 146, col: 37, offset: 3237},
 								expr: &seqExpr{
-									pos: position{line: 146, col: 38, offset: 3237},
+									pos: position{line: 146, col: 38, offset: 3238},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 146, col: 38, offset: 3237},
+											pos:        position{line: 146, col: 38, offset: 3238},
 											val:        "=",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 146, col: 42, offset: 3241},
+											pos:  position{line: 146, col: 42, offset: 3242},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 146, col: 44, offset: 3243},
+											pos:  position{line: 146, col: 44, offset: 3244},
 											name: "IntConstant",
 										},
 									},
@@ -437,9 +437,9 @@ var g = &grammar{
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 146, col: 58, offset: 3257},
+							pos: position{line: 146, col: 58, offset: 3258},
 							expr: &ruleRefExpr{
-								pos:  position{line: 146, col: 58, offset: 3257},
+								pos:  position{line: 146, col: 58, offset: 3258},
 								name: "ListSeparator",
 							},
 						},
@@ -449,44 +449,44 @@ var g = &grammar{
 		},
 		{
 			name: "TypeDef",
-			pos:  position{line: 157, col: 1, offset: 3436},
+			pos:  position{line: 157, col: 1, offset: 3437},
 			expr: &actionExpr{
-				pos: position{line: 157, col: 11, offset: 3448},
+				pos: position{line: 157, col: 11, offset: 3449},
 				run: (*parser).callonTypeDef1,
 				expr: &seqExpr{
-					pos: position{line: 157, col: 11, offset: 3448},
+					pos: position{line: 157, col: 11, offset: 3449},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 157, col: 11, offset: 3448},
+							pos:        position{line: 157, col: 11, offset: 3449},
 							val:        "typedef",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 157, col: 21, offset: 3458},
+							pos:  position{line: 157, col: 21, offset: 3459},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 157, col: 23, offset: 3460},
+							pos:   position{line: 157, col: 23, offset: 3461},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 157, col: 27, offset: 3464},
+								pos:  position{line: 157, col: 27, offset: 3465},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 157, col: 37, offset: 3474},
+							pos:  position{line: 157, col: 37, offset: 3475},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 157, col: 39, offset: 3476},
+							pos:   position{line: 157, col: 39, offset: 3477},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 157, col: 44, offset: 3481},
+								pos:  position{line: 157, col: 44, offset: 3482},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 157, col: 55, offset: 3492},
+							pos:  position{line: 157, col: 55, offset: 3493},
 							name: "EOS",
 						},
 					},
@@ -495,27 +495,27 @@ var g = &grammar{
 		},
 		{
 			name: "Struct",
-			pos:  position{line: 164, col: 1, offset: 3582},
+			pos:  position{line: 164, col: 1, offset: 3583},
 			expr: &actionExpr{
-				pos: position{line: 164, col: 10, offset: 3593},
+				pos: position{line: 164, col: 10, offset: 3594},
 				run: (*parser).callonStruct1,
 				expr: &seqExpr{
-					pos: position{line: 164, col: 10, offset: 3593},
+					pos: position{line: 164, col: 10, offset: 3594},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 164, col: 10, offset: 3593},
+							pos:        position{line: 164, col: 10, offset: 3594},
 							val:        "struct",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 164, col: 19, offset: 3602},
+							pos:  position{line: 164, col: 19, offset: 3603},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 164, col: 21, offset: 3604},
+							pos:   position{line: 164, col: 21, offset: 3605},
 							label: "st",
 							expr: &ruleRefExpr{
-								pos:  position{line: 164, col: 24, offset: 3607},
+								pos:  position{line: 164, col: 24, offset: 3608},
 								name: "StructLike",
 							},
 						},
@@ -525,27 +525,27 @@ var g = &grammar{
 		},
 		{
 			name: "Exception",
-			pos:  position{line: 165, col: 1, offset: 3647},
+			pos:  position{line: 165, col: 1, offset: 3648},
 			expr: &actionExpr{
-				pos: position{line: 165, col: 13, offset: 3661},
+				pos: position{line: 165, col: 13, offset: 3662},
 				run: (*parser).callonException1,
 				expr: &seqExpr{
-					pos: position{line: 165, col: 13, offset: 3661},
+					pos: position{line: 165, col: 13, offset: 3662},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 165, col: 13, offset: 3661},
+							pos:        position{line: 165, col: 13, offset: 3662},
 							val:        "exception",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 165, col: 25, offset: 3673},
+							pos:  position{line: 165, col: 25, offset: 3674},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 165, col: 27, offset: 3675},
+							pos:   position{line: 165, col: 27, offset: 3676},
 							label: "st",
 							expr: &ruleRefExpr{
-								pos:  position{line: 165, col: 30, offset: 3678},
+								pos:  position{line: 165, col: 30, offset: 3679},
 								name: "StructLike",
 							},
 						},
@@ -555,27 +555,27 @@ var g = &grammar{
 		},
 		{
 			name: "Union",
-			pos:  position{line: 166, col: 1, offset: 3729},
+			pos:  position{line: 166, col: 1, offset: 3730},
 			expr: &actionExpr{
-				pos: position{line: 166, col: 9, offset: 3739},
+				pos: position{line: 166, col: 9, offset: 3740},
 				run: (*parser).callonUnion1,
 				expr: &seqExpr{
-					pos: position{line: 166, col: 9, offset: 3739},
+					pos: position{line: 166, col: 9, offset: 3740},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 166, col: 9, offset: 3739},
+							pos:        position{line: 166, col: 9, offset: 3740},
 							val:        "union",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 166, col: 17, offset: 3747},
+							pos:  position{line: 166, col: 17, offset: 3748},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 166, col: 19, offset: 3749},
+							pos:   position{line: 166, col: 19, offset: 3750},
 							label: "st",
 							expr: &ruleRefExpr{
-								pos:  position{line: 166, col: 22, offset: 3752},
+								pos:  position{line: 166, col: 22, offset: 3753},
 								name: "StructLike",
 							},
 						},
@@ -585,49 +585,49 @@ var g = &grammar{
 		},
 		{
 			name: "StructLike",
-			pos:  position{line: 167, col: 1, offset: 3799},
+			pos:  position{line: 167, col: 1, offset: 3800},
 			expr: &actionExpr{
-				pos: position{line: 167, col: 14, offset: 3814},
+				pos: position{line: 167, col: 14, offset: 3815},
 				run: (*parser).callonStructLike1,
 				expr: &seqExpr{
-					pos: position{line: 167, col: 14, offset: 3814},
+					pos: position{line: 167, col: 14, offset: 3815},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 167, col: 14, offset: 3814},
+							pos:   position{line: 167, col: 14, offset: 3815},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 167, col: 19, offset: 3819},
+								pos:  position{line: 167, col: 19, offset: 3820},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 167, col: 30, offset: 3830},
+							pos:  position{line: 167, col: 30, offset: 3831},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 167, col: 33, offset: 3833},
+							pos:        position{line: 167, col: 33, offset: 3834},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 167, col: 37, offset: 3837},
+							pos:  position{line: 167, col: 37, offset: 3838},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 167, col: 40, offset: 3840},
+							pos:   position{line: 167, col: 40, offset: 3841},
 							label: "fields",
 							expr: &ruleRefExpr{
-								pos:  position{line: 167, col: 47, offset: 3847},
+								pos:  position{line: 167, col: 47, offset: 3848},
 								name: "FieldList",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 167, col: 57, offset: 3857},
+							pos:        position{line: 167, col: 57, offset: 3858},
 							val:        "}",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 167, col: 61, offset: 3861},
+							pos:  position{line: 167, col: 61, offset: 3862},
 							name: "EOS",
 						},
 					},
@@ -636,24 +636,24 @@ var g = &grammar{
 		},
 		{
 			name: "FieldList",
-			pos:  position{line: 177, col: 1, offset: 3995},
+			pos:  position{line: 177, col: 1, offset: 3996},
 			expr: &actionExpr{
-				pos: position{line: 177, col: 13, offset: 4009},
+				pos: position{line: 177, col: 13, offset: 4010},
 				run: (*parser).callonFieldList1,
 				expr: &labeledExpr{
-					pos:   position{line: 177, col: 13, offset: 4009},
+					pos:   position{line: 177, col: 13, offset: 4010},
 					label: "fields",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 177, col: 20, offset: 4016},
+						pos: position{line: 177, col: 20, offset: 4017},
 						expr: &seqExpr{
-							pos: position{line: 177, col: 21, offset: 4017},
+							pos: position{line: 177, col: 21, offset: 4018},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 177, col: 21, offset: 4017},
+									pos:  position{line: 177, col: 21, offset: 4018},
 									name: "Field",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 177, col: 27, offset: 4023},
+									pos:  position{line: 177, col: 27, offset: 4024},
 									name: "__",
 								},
 							},
@@ -664,92 +664,92 @@ var g = &grammar{
 		},
 		{
 			name: "Field",
-			pos:  position{line: 186, col: 1, offset: 4183},
+			pos:  position{line: 186, col: 1, offset: 4184},
 			expr: &actionExpr{
-				pos: position{line: 186, col: 9, offset: 4193},
+				pos: position{line: 186, col: 9, offset: 4194},
 				run: (*parser).callonField1,
 				expr: &seqExpr{
-					pos: position{line: 186, col: 9, offset: 4193},
+					pos: position{line: 186, col: 9, offset: 4194},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 186, col: 9, offset: 4193},
+							pos:   position{line: 186, col: 9, offset: 4194},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 186, col: 12, offset: 4196},
+								pos:  position{line: 186, col: 12, offset: 4197},
 								name: "IntConstant",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 186, col: 24, offset: 4208},
+							pos:  position{line: 186, col: 24, offset: 4209},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 186, col: 26, offset: 4210},
+							pos:        position{line: 186, col: 26, offset: 4211},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 186, col: 30, offset: 4214},
+							pos:  position{line: 186, col: 30, offset: 4215},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 186, col: 32, offset: 4216},
+							pos:   position{line: 186, col: 32, offset: 4217},
 							label: "req",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 186, col: 36, offset: 4220},
+								pos: position{line: 186, col: 36, offset: 4221},
 								expr: &ruleRefExpr{
-									pos:  position{line: 186, col: 36, offset: 4220},
+									pos:  position{line: 186, col: 36, offset: 4221},
 									name: "FieldReq",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 186, col: 46, offset: 4230},
+							pos:  position{line: 186, col: 46, offset: 4231},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 186, col: 48, offset: 4232},
+							pos:   position{line: 186, col: 48, offset: 4233},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 186, col: 52, offset: 4236},
+								pos:  position{line: 186, col: 52, offset: 4237},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 186, col: 62, offset: 4246},
+							pos:  position{line: 186, col: 62, offset: 4247},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 186, col: 64, offset: 4248},
+							pos:   position{line: 186, col: 64, offset: 4249},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 186, col: 69, offset: 4253},
+								pos:  position{line: 186, col: 69, offset: 4254},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 186, col: 80, offset: 4264},
+							pos:  position{line: 186, col: 80, offset: 4265},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 186, col: 83, offset: 4267},
+							pos:   position{line: 186, col: 83, offset: 4268},
 							label: "def",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 186, col: 87, offset: 4271},
+								pos: position{line: 186, col: 87, offset: 4272},
 								expr: &seqExpr{
-									pos: position{line: 186, col: 88, offset: 4272},
+									pos: position{line: 186, col: 88, offset: 4273},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 186, col: 88, offset: 4272},
+											pos:        position{line: 186, col: 88, offset: 4273},
 											val:        "=",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 186, col: 92, offset: 4276},
+											pos:  position{line: 186, col: 92, offset: 4277},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 186, col: 94, offset: 4278},
+											pos:  position{line: 186, col: 94, offset: 4279},
 											name: "ConstValue",
 										},
 									},
@@ -757,9 +757,9 @@ var g = &grammar{
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 186, col: 107, offset: 4291},
+							pos: position{line: 186, col: 107, offset: 4292},
 							expr: &ruleRefExpr{
-								pos:  position{line: 186, col: 107, offset: 4291},
+								pos:  position{line: 186, col: 107, offset: 4292},
 								name: "ListSeparator",
 							},
 						},
@@ -769,20 +769,20 @@ var g = &grammar{
 		},
 		{
 			name: "FieldReq",
-			pos:  position{line: 201, col: 1, offset: 4551},
+			pos:  position{line: 201, col: 1, offset: 4552},
 			expr: &actionExpr{
-				pos: position{line: 201, col: 12, offset: 4564},
+				pos: position{line: 201, col: 12, offset: 4565},
 				run: (*parser).callonFieldReq1,
 				expr: &choiceExpr{
-					pos: position{line: 201, col: 13, offset: 4565},
+					pos: position{line: 201, col: 13, offset: 4566},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 201, col: 13, offset: 4565},
+							pos:        position{line: 201, col: 13, offset: 4566},
 							val:        "required",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 201, col: 26, offset: 4578},
+							pos:        position{line: 201, col: 26, offset: 4579},
 							val:        "optional",
 							ignoreCase: false,
 						},
@@ -792,57 +792,57 @@ var g = &grammar{
 		},
 		{
 			name: "Service",
-			pos:  position{line: 205, col: 1, offset: 4649},
+			pos:  position{line: 205, col: 1, offset: 4650},
 			expr: &actionExpr{
-				pos: position{line: 205, col: 11, offset: 4661},
+				pos: position{line: 205, col: 11, offset: 4662},
 				run: (*parser).callonService1,
 				expr: &seqExpr{
-					pos: position{line: 205, col: 11, offset: 4661},
+					pos: position{line: 205, col: 11, offset: 4662},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 205, col: 11, offset: 4661},
+							pos:        position{line: 205, col: 11, offset: 4662},
 							val:        "service",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 205, col: 21, offset: 4671},
+							pos:  position{line: 205, col: 21, offset: 4672},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 205, col: 23, offset: 4673},
+							pos:   position{line: 205, col: 23, offset: 4674},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 205, col: 28, offset: 4678},
+								pos:  position{line: 205, col: 28, offset: 4679},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 205, col: 39, offset: 4689},
+							pos:  position{line: 205, col: 39, offset: 4690},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 205, col: 41, offset: 4691},
+							pos:   position{line: 205, col: 41, offset: 4692},
 							label: "extends",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 205, col: 49, offset: 4699},
+								pos: position{line: 205, col: 49, offset: 4700},
 								expr: &seqExpr{
-									pos: position{line: 205, col: 50, offset: 4700},
+									pos: position{line: 205, col: 50, offset: 4701},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 205, col: 50, offset: 4700},
+											pos:        position{line: 205, col: 50, offset: 4701},
 											val:        "extends",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 205, col: 60, offset: 4710},
+											pos:  position{line: 205, col: 60, offset: 4711},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 205, col: 63, offset: 4713},
+											pos:  position{line: 205, col: 63, offset: 4714},
 											name: "Identifier",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 205, col: 74, offset: 4724},
+											pos:  position{line: 205, col: 74, offset: 4725},
 											name: "__",
 										},
 									},
@@ -850,32 +850,32 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 205, col: 79, offset: 4729},
+							pos:  position{line: 205, col: 79, offset: 4730},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 205, col: 82, offset: 4732},
+							pos:        position{line: 205, col: 82, offset: 4733},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 205, col: 86, offset: 4736},
+							pos:  position{line: 205, col: 86, offset: 4737},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 205, col: 89, offset: 4739},
+							pos:   position{line: 205, col: 89, offset: 4740},
 							label: "methods",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 205, col: 97, offset: 4747},
+								pos: position{line: 205, col: 97, offset: 4748},
 								expr: &seqExpr{
-									pos: position{line: 205, col: 98, offset: 4748},
+									pos: position{line: 205, col: 98, offset: 4749},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 205, col: 98, offset: 4748},
+											pos:  position{line: 205, col: 98, offset: 4749},
 											name: "Function",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 205, col: 107, offset: 4757},
+											pos:  position{line: 205, col: 107, offset: 4758},
 											name: "__",
 										},
 									},
@@ -883,21 +883,21 @@ var g = &grammar{
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 205, col: 113, offset: 4763},
+							pos: position{line: 205, col: 113, offset: 4764},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 205, col: 113, offset: 4763},
+									pos:        position{line: 205, col: 113, offset: 4764},
 									val:        "}",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 205, col: 119, offset: 4769},
+									pos:  position{line: 205, col: 119, offset: 4770},
 									name: "EndOfServiceError",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 205, col: 138, offset: 4788},
+							pos:  position{line: 205, col: 138, offset: 4789},
 							name: "EOS",
 						},
 					},
@@ -906,39 +906,39 @@ var g = &grammar{
 		},
 		{
 			name: "EndOfServiceError",
-			pos:  position{line: 220, col: 1, offset: 5129},
+			pos:  position{line: 220, col: 1, offset: 5130},
 			expr: &actionExpr{
-				pos: position{line: 220, col: 21, offset: 5151},
+				pos: position{line: 220, col: 21, offset: 5152},
 				run: (*parser).callonEndOfServiceError1,
 				expr: &anyMatcher{
-					line: 220, col: 21, offset: 5151,
+					line: 220, col: 21, offset: 5152,
 				},
 			},
 		},
 		{
 			name: "Function",
-			pos:  position{line: 224, col: 1, offset: 5217},
+			pos:  position{line: 224, col: 1, offset: 5218},
 			expr: &actionExpr{
-				pos: position{line: 224, col: 12, offset: 5230},
+				pos: position{line: 224, col: 12, offset: 5231},
 				run: (*parser).callonFunction1,
 				expr: &seqExpr{
-					pos: position{line: 224, col: 12, offset: 5230},
+					pos: position{line: 224, col: 12, offset: 5231},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 224, col: 12, offset: 5230},
+							pos:   position{line: 224, col: 12, offset: 5231},
 							label: "oneway",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 224, col: 19, offset: 5237},
+								pos: position{line: 224, col: 19, offset: 5238},
 								expr: &seqExpr{
-									pos: position{line: 224, col: 20, offset: 5238},
+									pos: position{line: 224, col: 20, offset: 5239},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 224, col: 20, offset: 5238},
+											pos:        position{line: 224, col: 20, offset: 5239},
 											val:        "oneway",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 224, col: 29, offset: 5247},
+											pos:  position{line: 224, col: 29, offset: 5248},
 											name: "__",
 										},
 									},
@@ -946,70 +946,70 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 224, col: 34, offset: 5252},
+							pos:   position{line: 224, col: 34, offset: 5253},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 224, col: 38, offset: 5256},
+								pos:  position{line: 224, col: 38, offset: 5257},
 								name: "FunctionType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 224, col: 51, offset: 5269},
+							pos:  position{line: 224, col: 51, offset: 5270},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 224, col: 54, offset: 5272},
+							pos:   position{line: 224, col: 54, offset: 5273},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 224, col: 59, offset: 5277},
+								pos:  position{line: 224, col: 59, offset: 5278},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 224, col: 70, offset: 5288},
+							pos:  position{line: 224, col: 70, offset: 5289},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 224, col: 72, offset: 5290},
+							pos:        position{line: 224, col: 72, offset: 5291},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 224, col: 76, offset: 5294},
+							pos:  position{line: 224, col: 76, offset: 5295},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 224, col: 79, offset: 5297},
+							pos:   position{line: 224, col: 79, offset: 5298},
 							label: "arguments",
 							expr: &ruleRefExpr{
-								pos:  position{line: 224, col: 89, offset: 5307},
+								pos:  position{line: 224, col: 89, offset: 5308},
 								name: "FieldList",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 224, col: 99, offset: 5317},
+							pos:        position{line: 224, col: 99, offset: 5318},
 							val:        ")",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 224, col: 103, offset: 5321},
+							pos:  position{line: 224, col: 103, offset: 5322},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 224, col: 106, offset: 5324},
+							pos:   position{line: 224, col: 106, offset: 5325},
 							label: "exceptions",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 224, col: 117, offset: 5335},
+								pos: position{line: 224, col: 117, offset: 5336},
 								expr: &ruleRefExpr{
-									pos:  position{line: 224, col: 117, offset: 5335},
+									pos:  position{line: 224, col: 117, offset: 5336},
 									name: "Throws",
 								},
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 224, col: 125, offset: 5343},
+							pos: position{line: 224, col: 125, offset: 5344},
 							expr: &ruleRefExpr{
-								pos:  position{line: 224, col: 125, offset: 5343},
+								pos:  position{line: 224, col: 125, offset: 5344},
 								name: "ListSeparator",
 							},
 						},
@@ -1019,23 +1019,23 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionType",
-			pos:  position{line: 247, col: 1, offset: 5724},
+			pos:  position{line: 247, col: 1, offset: 5725},
 			expr: &actionExpr{
-				pos: position{line: 247, col: 16, offset: 5741},
+				pos: position{line: 247, col: 16, offset: 5742},
 				run: (*parser).callonFunctionType1,
 				expr: &labeledExpr{
-					pos:   position{line: 247, col: 16, offset: 5741},
+					pos:   position{line: 247, col: 16, offset: 5742},
 					label: "typ",
 					expr: &choiceExpr{
-						pos: position{line: 247, col: 21, offset: 5746},
+						pos: position{line: 247, col: 21, offset: 5747},
 						alternatives: []interface{}{
 							&litMatcher{
-								pos:        position{line: 247, col: 21, offset: 5746},
+								pos:        position{line: 247, col: 21, offset: 5747},
 								val:        "void",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 247, col: 30, offset: 5755},
+								pos:  position{line: 247, col: 30, offset: 5756},
 								name: "FieldType",
 							},
 						},
@@ -1045,41 +1045,41 @@ var g = &grammar{
 		},
 		{
 			name: "Throws",
-			pos:  position{line: 254, col: 1, offset: 5862},
+			pos:  position{line: 254, col: 1, offset: 5863},
 			expr: &actionExpr{
-				pos: position{line: 254, col: 10, offset: 5873},
+				pos: position{line: 254, col: 10, offset: 5874},
 				run: (*parser).callonThrows1,
 				expr: &seqExpr{
-					pos: position{line: 254, col: 10, offset: 5873},
+					pos: position{line: 254, col: 10, offset: 5874},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 254, col: 10, offset: 5873},
+							pos:        position{line: 254, col: 10, offset: 5874},
 							val:        "throws",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 254, col: 19, offset: 5882},
+							pos:  position{line: 254, col: 19, offset: 5883},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 254, col: 22, offset: 5885},
+							pos:        position{line: 254, col: 22, offset: 5886},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 254, col: 26, offset: 5889},
+							pos:  position{line: 254, col: 26, offset: 5890},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 254, col: 29, offset: 5892},
+							pos:   position{line: 254, col: 29, offset: 5893},
 							label: "exceptions",
 							expr: &ruleRefExpr{
-								pos:  position{line: 254, col: 40, offset: 5903},
+								pos:  position{line: 254, col: 40, offset: 5904},
 								name: "FieldList",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 254, col: 50, offset: 5913},
+							pos:        position{line: 254, col: 50, offset: 5914},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -1089,26 +1089,26 @@ var g = &grammar{
 		},
 		{
 			name: "FieldType",
-			pos:  position{line: 258, col: 1, offset: 5946},
+			pos:  position{line: 258, col: 1, offset: 5947},
 			expr: &actionExpr{
-				pos: position{line: 258, col: 13, offset: 5960},
+				pos: position{line: 258, col: 13, offset: 5961},
 				run: (*parser).callonFieldType1,
 				expr: &labeledExpr{
-					pos:   position{line: 258, col: 13, offset: 5960},
+					pos:   position{line: 258, col: 13, offset: 5961},
 					label: "typ",
 					expr: &choiceExpr{
-						pos: position{line: 258, col: 18, offset: 5965},
+						pos: position{line: 258, col: 18, offset: 5966},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 258, col: 18, offset: 5965},
+								pos:  position{line: 258, col: 18, offset: 5966},
 								name: "BaseType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 258, col: 29, offset: 5976},
+								pos:  position{line: 258, col: 29, offset: 5977},
 								name: "ContainerType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 258, col: 45, offset: 5992},
+								pos:  position{line: 258, col: 45, offset: 5993},
 								name: "Identifier",
 							},
 						},
@@ -1118,22 +1118,22 @@ var g = &grammar{
 		},
 		{
 			name: "DefinitionType",
-			pos:  position{line: 265, col: 1, offset: 6102},
+			pos:  position{line: 265, col: 1, offset: 6103},
 			expr: &actionExpr{
-				pos: position{line: 265, col: 18, offset: 6121},
+				pos: position{line: 265, col: 18, offset: 6122},
 				run: (*parser).callonDefinitionType1,
 				expr: &labeledExpr{
-					pos:   position{line: 265, col: 18, offset: 6121},
+					pos:   position{line: 265, col: 18, offset: 6122},
 					label: "typ",
 					expr: &choiceExpr{
-						pos: position{line: 265, col: 23, offset: 6126},
+						pos: position{line: 265, col: 23, offset: 6127},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 265, col: 23, offset: 6126},
+								pos:  position{line: 265, col: 23, offset: 6127},
 								name: "BaseType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 265, col: 34, offset: 6137},
+								pos:  position{line: 265, col: 34, offset: 6138},
 								name: "ContainerType",
 							},
 						},
@@ -1143,50 +1143,50 @@ var g = &grammar{
 		},
 		{
 			name: "BaseType",
-			pos:  position{line: 269, col: 1, offset: 6174},
+			pos:  position{line: 269, col: 1, offset: 6175},
 			expr: &actionExpr{
-				pos: position{line: 269, col: 12, offset: 6187},
+				pos: position{line: 269, col: 12, offset: 6188},
 				run: (*parser).callonBaseType1,
 				expr: &choiceExpr{
-					pos: position{line: 269, col: 13, offset: 6188},
+					pos: position{line: 269, col: 13, offset: 6189},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 269, col: 13, offset: 6188},
+							pos:        position{line: 269, col: 13, offset: 6189},
 							val:        "bool",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 269, col: 22, offset: 6197},
+							pos:        position{line: 269, col: 22, offset: 6198},
 							val:        "byte",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 269, col: 31, offset: 6206},
+							pos:        position{line: 269, col: 31, offset: 6207},
 							val:        "i16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 269, col: 39, offset: 6214},
+							pos:        position{line: 269, col: 39, offset: 6215},
 							val:        "i32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 269, col: 47, offset: 6222},
+							pos:        position{line: 269, col: 47, offset: 6223},
 							val:        "i64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 269, col: 55, offset: 6230},
+							pos:        position{line: 269, col: 55, offset: 6231},
 							val:        "double",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 269, col: 66, offset: 6241},
+							pos:        position{line: 269, col: 66, offset: 6242},
 							val:        "string",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 269, col: 77, offset: 6252},
+							pos:        position{line: 269, col: 77, offset: 6253},
 							val:        "binary",
 							ignoreCase: false,
 						},
@@ -1196,26 +1196,26 @@ var g = &grammar{
 		},
 		{
 			name: "ContainerType",
-			pos:  position{line: 273, col: 1, offset: 6309},
+			pos:  position{line: 273, col: 1, offset: 6310},
 			expr: &actionExpr{
-				pos: position{line: 273, col: 17, offset: 6327},
+				pos: position{line: 273, col: 17, offset: 6328},
 				run: (*parser).callonContainerType1,
 				expr: &labeledExpr{
-					pos:   position{line: 273, col: 17, offset: 6327},
+					pos:   position{line: 273, col: 17, offset: 6328},
 					label: "typ",
 					expr: &choiceExpr{
-						pos: position{line: 273, col: 22, offset: 6332},
+						pos: position{line: 273, col: 22, offset: 6333},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 273, col: 22, offset: 6332},
+								pos:  position{line: 273, col: 22, offset: 6333},
 								name: "MapType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 273, col: 32, offset: 6342},
+								pos:  position{line: 273, col: 32, offset: 6343},
 								name: "SetType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 273, col: 42, offset: 6352},
+								pos:  position{line: 273, col: 42, offset: 6353},
 								name: "ListType",
 							},
 						},
@@ -1225,64 +1225,64 @@ var g = &grammar{
 		},
 		{
 			name: "MapType",
-			pos:  position{line: 277, col: 1, offset: 6384},
+			pos:  position{line: 277, col: 1, offset: 6385},
 			expr: &actionExpr{
-				pos: position{line: 277, col: 11, offset: 6396},
+				pos: position{line: 277, col: 11, offset: 6397},
 				run: (*parser).callonMapType1,
 				expr: &seqExpr{
-					pos: position{line: 277, col: 11, offset: 6396},
+					pos: position{line: 277, col: 11, offset: 6397},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 277, col: 11, offset: 6396},
+							pos: position{line: 277, col: 11, offset: 6397},
 							expr: &ruleRefExpr{
-								pos:  position{line: 277, col: 11, offset: 6396},
+								pos:  position{line: 277, col: 11, offset: 6397},
 								name: "CppType",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 277, col: 20, offset: 6405},
+							pos:        position{line: 277, col: 20, offset: 6406},
 							val:        "map<",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 277, col: 27, offset: 6412},
+							pos:  position{line: 277, col: 27, offset: 6413},
 							name: "WS",
 						},
 						&labeledExpr{
-							pos:   position{line: 277, col: 30, offset: 6415},
+							pos:   position{line: 277, col: 30, offset: 6416},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 277, col: 34, offset: 6419},
+								pos:  position{line: 277, col: 34, offset: 6420},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 277, col: 44, offset: 6429},
+							pos:  position{line: 277, col: 44, offset: 6430},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 277, col: 47, offset: 6432},
+							pos:        position{line: 277, col: 47, offset: 6433},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 277, col: 51, offset: 6436},
+							pos:  position{line: 277, col: 51, offset: 6437},
 							name: "WS",
 						},
 						&labeledExpr{
-							pos:   position{line: 277, col: 54, offset: 6439},
+							pos:   position{line: 277, col: 54, offset: 6440},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 277, col: 60, offset: 6445},
+								pos:  position{line: 277, col: 60, offset: 6446},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 277, col: 70, offset: 6455},
+							pos:  position{line: 277, col: 70, offset: 6456},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 277, col: 73, offset: 6458},
+							pos:        position{line: 277, col: 73, offset: 6459},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -1292,43 +1292,43 @@ var g = &grammar{
 		},
 		{
 			name: "SetType",
-			pos:  position{line: 285, col: 1, offset: 6557},
+			pos:  position{line: 285, col: 1, offset: 6558},
 			expr: &actionExpr{
-				pos: position{line: 285, col: 11, offset: 6569},
+				pos: position{line: 285, col: 11, offset: 6570},
 				run: (*parser).callonSetType1,
 				expr: &seqExpr{
-					pos: position{line: 285, col: 11, offset: 6569},
+					pos: position{line: 285, col: 11, offset: 6570},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 285, col: 11, offset: 6569},
+							pos: position{line: 285, col: 11, offset: 6570},
 							expr: &ruleRefExpr{
-								pos:  position{line: 285, col: 11, offset: 6569},
+								pos:  position{line: 285, col: 11, offset: 6570},
 								name: "CppType",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 285, col: 20, offset: 6578},
+							pos:        position{line: 285, col: 20, offset: 6579},
 							val:        "set<",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 285, col: 27, offset: 6585},
+							pos:  position{line: 285, col: 27, offset: 6586},
 							name: "WS",
 						},
 						&labeledExpr{
-							pos:   position{line: 285, col: 30, offset: 6588},
+							pos:   position{line: 285, col: 30, offset: 6589},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 285, col: 34, offset: 6592},
+								pos:  position{line: 285, col: 34, offset: 6593},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 285, col: 44, offset: 6602},
+							pos:  position{line: 285, col: 44, offset: 6603},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 285, col: 47, offset: 6605},
+							pos:        position{line: 285, col: 47, offset: 6606},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -1338,36 +1338,36 @@ var g = &grammar{
 		},
 		{
 			name: "ListType",
-			pos:  position{line: 292, col: 1, offset: 6678},
+			pos:  position{line: 292, col: 1, offset: 6679},
 			expr: &actionExpr{
-				pos: position{line: 292, col: 12, offset: 6691},
+				pos: position{line: 292, col: 12, offset: 6692},
 				run: (*parser).callonListType1,
 				expr: &seqExpr{
-					pos: position{line: 292, col: 12, offset: 6691},
+					pos: position{line: 292, col: 12, offset: 6692},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 292, col: 12, offset: 6691},
+							pos:        position{line: 292, col: 12, offset: 6692},
 							val:        "list<",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 292, col: 20, offset: 6699},
+							pos:  position{line: 292, col: 20, offset: 6700},
 							name: "WS",
 						},
 						&labeledExpr{
-							pos:   position{line: 292, col: 23, offset: 6702},
+							pos:   position{line: 292, col: 23, offset: 6703},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 292, col: 27, offset: 6706},
+								pos:  position{line: 292, col: 27, offset: 6707},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 292, col: 37, offset: 6716},
+							pos:  position{line: 292, col: 37, offset: 6717},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 292, col: 40, offset: 6719},
+							pos:        position{line: 292, col: 40, offset: 6720},
 							val:        ">",
 							ignoreCase: false,
 						},
@@ -1377,23 +1377,23 @@ var g = &grammar{
 		},
 		{
 			name: "CppType",
-			pos:  position{line: 299, col: 1, offset: 6793},
+			pos:  position{line: 299, col: 1, offset: 6794},
 			expr: &actionExpr{
-				pos: position{line: 299, col: 11, offset: 6805},
+				pos: position{line: 299, col: 11, offset: 6806},
 				run: (*parser).callonCppType1,
 				expr: &seqExpr{
-					pos: position{line: 299, col: 11, offset: 6805},
+					pos: position{line: 299, col: 11, offset: 6806},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 299, col: 11, offset: 6805},
+							pos:        position{line: 299, col: 11, offset: 6806},
 							val:        "cpp_type",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 299, col: 22, offset: 6816},
+							pos:   position{line: 299, col: 22, offset: 6817},
 							label: "cppType",
 							expr: &ruleRefExpr{
-								pos:  position{line: 299, col: 30, offset: 6824},
+								pos:  position{line: 299, col: 30, offset: 6825},
 								name: "Literal",
 							},
 						},
@@ -1403,32 +1403,32 @@ var g = &grammar{
 		},
 		{
 			name: "ConstValue",
-			pos:  position{line: 303, col: 1, offset: 6858},
+			pos:  position{line: 303, col: 1, offset: 6859},
 			expr: &choiceExpr{
-				pos: position{line: 303, col: 14, offset: 6873},
+				pos: position{line: 303, col: 14, offset: 6874},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 303, col: 14, offset: 6873},
+						pos:  position{line: 303, col: 14, offset: 6874},
 						name: "Literal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 303, col: 24, offset: 6883},
+						pos:  position{line: 303, col: 24, offset: 6884},
 						name: "DoubleConstant",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 303, col: 41, offset: 6900},
+						pos:  position{line: 303, col: 41, offset: 6901},
 						name: "IntConstant",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 303, col: 55, offset: 6914},
+						pos:  position{line: 303, col: 55, offset: 6915},
 						name: "ConstMap",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 303, col: 66, offset: 6925},
+						pos:  position{line: 303, col: 66, offset: 6926},
 						name: "ConstList",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 303, col: 78, offset: 6937},
+						pos:  position{line: 303, col: 78, offset: 6938},
 						name: "Identifier",
 					},
 				},
@@ -1436,17 +1436,17 @@ var g = &grammar{
 		},
 		{
 			name: "IntConstant",
-			pos:  position{line: 305, col: 1, offset: 6949},
+			pos:  position{line: 305, col: 1, offset: 6950},
 			expr: &actionExpr{
-				pos: position{line: 305, col: 15, offset: 6965},
+				pos: position{line: 305, col: 15, offset: 6966},
 				run: (*parser).callonIntConstant1,
 				expr: &seqExpr{
-					pos: position{line: 305, col: 15, offset: 6965},
+					pos: position{line: 305, col: 15, offset: 6966},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 305, col: 15, offset: 6965},
+							pos: position{line: 305, col: 15, offset: 6966},
 							expr: &charClassMatcher{
-								pos:        position{line: 305, col: 15, offset: 6965},
+								pos:        position{line: 305, col: 15, offset: 6966},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -1454,9 +1454,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 305, col: 21, offset: 6971},
+							pos: position{line: 305, col: 21, offset: 6972},
 							expr: &ruleRefExpr{
-								pos:  position{line: 305, col: 21, offset: 6971},
+								pos:  position{line: 305, col: 21, offset: 6972},
 								name: "Digit",
 							},
 						},
@@ -1466,17 +1466,17 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleConstant",
-			pos:  position{line: 309, col: 1, offset: 7032},
+			pos:  position{line: 309, col: 1, offset: 7033},
 			expr: &actionExpr{
-				pos: position{line: 309, col: 18, offset: 7051},
+				pos: position{line: 309, col: 18, offset: 7052},
 				run: (*parser).callonDoubleConstant1,
 				expr: &seqExpr{
-					pos: position{line: 309, col: 18, offset: 7051},
+					pos: position{line: 309, col: 18, offset: 7052},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 309, col: 18, offset: 7051},
+							pos: position{line: 309, col: 18, offset: 7052},
 							expr: &charClassMatcher{
-								pos:        position{line: 309, col: 18, offset: 7051},
+								pos:        position{line: 309, col: 18, offset: 7052},
 								val:        "[+-]",
 								chars:      []rune{'+', '-'},
 								ignoreCase: false,
@@ -1484,38 +1484,38 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 309, col: 24, offset: 7057},
+							pos: position{line: 309, col: 24, offset: 7058},
 							expr: &ruleRefExpr{
-								pos:  position{line: 309, col: 24, offset: 7057},
+								pos:  position{line: 309, col: 24, offset: 7058},
 								name: "Digit",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 309, col: 31, offset: 7064},
+							pos:        position{line: 309, col: 31, offset: 7065},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 309, col: 35, offset: 7068},
+							pos: position{line: 309, col: 35, offset: 7069},
 							expr: &ruleRefExpr{
-								pos:  position{line: 309, col: 35, offset: 7068},
+								pos:  position{line: 309, col: 35, offset: 7069},
 								name: "Digit",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 309, col: 42, offset: 7075},
+							pos: position{line: 309, col: 42, offset: 7076},
 							expr: &seqExpr{
-								pos: position{line: 309, col: 44, offset: 7077},
+								pos: position{line: 309, col: 44, offset: 7078},
 								exprs: []interface{}{
 									&charClassMatcher{
-										pos:        position{line: 309, col: 44, offset: 7077},
+										pos:        position{line: 309, col: 44, offset: 7078},
 										val:        "['Ee']",
 										chars:      []rune{'\'', 'E', 'e', '\''},
 										ignoreCase: false,
 										inverted:   false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 309, col: 51, offset: 7084},
+										pos:  position{line: 309, col: 51, offset: 7085},
 										name: "IntConstant",
 									},
 								},
@@ -1527,47 +1527,47 @@ var g = &grammar{
 		},
 		{
 			name: "ConstList",
-			pos:  position{line: 313, col: 1, offset: 7151},
+			pos:  position{line: 313, col: 1, offset: 7152},
 			expr: &actionExpr{
-				pos: position{line: 313, col: 13, offset: 7165},
+				pos: position{line: 313, col: 13, offset: 7166},
 				run: (*parser).callonConstList1,
 				expr: &seqExpr{
-					pos: position{line: 313, col: 13, offset: 7165},
+					pos: position{line: 313, col: 13, offset: 7166},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 313, col: 13, offset: 7165},
+							pos:        position{line: 313, col: 13, offset: 7166},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 313, col: 17, offset: 7169},
+							pos:  position{line: 313, col: 17, offset: 7170},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 313, col: 20, offset: 7172},
+							pos:   position{line: 313, col: 20, offset: 7173},
 							label: "values",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 313, col: 27, offset: 7179},
+								pos: position{line: 313, col: 27, offset: 7180},
 								expr: &seqExpr{
-									pos: position{line: 313, col: 28, offset: 7180},
+									pos: position{line: 313, col: 28, offset: 7181},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 313, col: 28, offset: 7180},
+											pos:  position{line: 313, col: 28, offset: 7181},
 											name: "ConstValue",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 313, col: 39, offset: 7191},
+											pos:  position{line: 313, col: 39, offset: 7192},
 											name: "__",
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 313, col: 42, offset: 7194},
+											pos: position{line: 313, col: 42, offset: 7195},
 											expr: &ruleRefExpr{
-												pos:  position{line: 313, col: 42, offset: 7194},
+												pos:  position{line: 313, col: 42, offset: 7195},
 												name: "ListSeparator",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 313, col: 57, offset: 7209},
+											pos:  position{line: 313, col: 57, offset: 7210},
 											name: "__",
 										},
 									},
@@ -1575,11 +1575,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 313, col: 62, offset: 7214},
+							pos:  position{line: 313, col: 62, offset: 7215},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 313, col: 65, offset: 7217},
+							pos:        position{line: 313, col: 65, offset: 7218},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -1589,67 +1589,67 @@ var g = &grammar{
 		},
 		{
 			name: "ConstMap",
-			pos:  position{line: 322, col: 1, offset: 7390},
+			pos:  position{line: 322, col: 1, offset: 7391},
 			expr: &actionExpr{
-				pos: position{line: 322, col: 12, offset: 7403},
+				pos: position{line: 322, col: 12, offset: 7404},
 				run: (*parser).callonConstMap1,
 				expr: &seqExpr{
-					pos: position{line: 322, col: 12, offset: 7403},
+					pos: position{line: 322, col: 12, offset: 7404},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 322, col: 12, offset: 7403},
+							pos:        position{line: 322, col: 12, offset: 7404},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 322, col: 16, offset: 7407},
+							pos:  position{line: 322, col: 16, offset: 7408},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 322, col: 19, offset: 7410},
+							pos:   position{line: 322, col: 19, offset: 7411},
 							label: "values",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 322, col: 26, offset: 7417},
+								pos: position{line: 322, col: 26, offset: 7418},
 								expr: &seqExpr{
-									pos: position{line: 322, col: 27, offset: 7418},
+									pos: position{line: 322, col: 27, offset: 7419},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 322, col: 27, offset: 7418},
+											pos:  position{line: 322, col: 27, offset: 7419},
 											name: "ConstValue",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 322, col: 38, offset: 7429},
+											pos:  position{line: 322, col: 38, offset: 7430},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 322, col: 41, offset: 7432},
+											pos:        position{line: 322, col: 41, offset: 7433},
 											val:        ":",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 322, col: 45, offset: 7436},
+											pos:  position{line: 322, col: 45, offset: 7437},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 322, col: 48, offset: 7439},
+											pos:  position{line: 322, col: 48, offset: 7440},
 											name: "ConstValue",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 322, col: 59, offset: 7450},
+											pos:  position{line: 322, col: 59, offset: 7451},
 											name: "__",
 										},
 										&choiceExpr{
-											pos: position{line: 322, col: 63, offset: 7454},
+											pos: position{line: 322, col: 63, offset: 7455},
 											alternatives: []interface{}{
 												&litMatcher{
-													pos:        position{line: 322, col: 63, offset: 7454},
+													pos:        position{line: 322, col: 63, offset: 7455},
 													val:        ",",
 													ignoreCase: false,
 												},
 												&andExpr{
-													pos: position{line: 322, col: 69, offset: 7460},
+													pos: position{line: 322, col: 69, offset: 7461},
 													expr: &litMatcher{
-														pos:        position{line: 322, col: 70, offset: 7461},
+														pos:        position{line: 322, col: 70, offset: 7462},
 														val:        "}",
 														ignoreCase: false,
 													},
@@ -1657,7 +1657,7 @@ var g = &grammar{
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 322, col: 75, offset: 7466},
+											pos:  position{line: 322, col: 75, offset: 7467},
 											name: "__",
 										},
 									},
@@ -1665,7 +1665,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 322, col: 80, offset: 7471},
+							pos:        position{line: 322, col: 80, offset: 7472},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -1675,33 +1675,33 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 338, col: 1, offset: 7717},
+			pos:  position{line: 338, col: 1, offset: 7718},
 			expr: &actionExpr{
-				pos: position{line: 338, col: 11, offset: 7729},
+				pos: position{line: 338, col: 11, offset: 7730},
 				run: (*parser).callonLiteral1,
 				expr: &choiceExpr{
-					pos: position{line: 338, col: 12, offset: 7730},
+					pos: position{line: 338, col: 12, offset: 7731},
 					alternatives: []interface{}{
 						&seqExpr{
-							pos: position{line: 338, col: 13, offset: 7731},
+							pos: position{line: 338, col: 13, offset: 7732},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 338, col: 13, offset: 7731},
+									pos:        position{line: 338, col: 13, offset: 7732},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 338, col: 17, offset: 7735},
+									pos: position{line: 338, col: 17, offset: 7736},
 									expr: &choiceExpr{
-										pos: position{line: 338, col: 18, offset: 7736},
+										pos: position{line: 338, col: 18, offset: 7737},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 338, col: 18, offset: 7736},
+												pos:        position{line: 338, col: 18, offset: 7737},
 												val:        "\\\"",
 												ignoreCase: false,
 											},
 											&charClassMatcher{
-												pos:        position{line: 338, col: 25, offset: 7743},
+												pos:        position{line: 338, col: 25, offset: 7744},
 												val:        "[^\"]",
 												chars:      []rune{'"'},
 												ignoreCase: false,
@@ -1711,32 +1711,32 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 338, col: 32, offset: 7750},
+									pos:        position{line: 338, col: 32, offset: 7751},
 									val:        "\"",
 									ignoreCase: false,
 								},
 							},
 						},
 						&seqExpr{
-							pos: position{line: 338, col: 40, offset: 7758},
+							pos: position{line: 338, col: 40, offset: 7759},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 338, col: 40, offset: 7758},
+									pos:        position{line: 338, col: 40, offset: 7759},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 338, col: 45, offset: 7763},
+									pos: position{line: 338, col: 45, offset: 7764},
 									expr: &choiceExpr{
-										pos: position{line: 338, col: 46, offset: 7764},
+										pos: position{line: 338, col: 46, offset: 7765},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 338, col: 46, offset: 7764},
+												pos:        position{line: 338, col: 46, offset: 7765},
 												val:        "\\'",
 												ignoreCase: false,
 											},
 											&charClassMatcher{
-												pos:        position{line: 338, col: 53, offset: 7771},
+												pos:        position{line: 338, col: 53, offset: 7772},
 												val:        "[^']",
 												chars:      []rune{'\''},
 												ignoreCase: false,
@@ -1746,7 +1746,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 338, col: 60, offset: 7778},
+									pos:        position{line: 338, col: 60, offset: 7779},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -1758,24 +1758,24 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 345, col: 1, offset: 7979},
+			pos:  position{line: 345, col: 1, offset: 7980},
 			expr: &actionExpr{
-				pos: position{line: 345, col: 14, offset: 7994},
+				pos: position{line: 345, col: 14, offset: 7995},
 				run: (*parser).callonIdentifier1,
 				expr: &seqExpr{
-					pos: position{line: 345, col: 14, offset: 7994},
+					pos: position{line: 345, col: 14, offset: 7995},
 					exprs: []interface{}{
 						&oneOrMoreExpr{
-							pos: position{line: 345, col: 14, offset: 7994},
+							pos: position{line: 345, col: 14, offset: 7995},
 							expr: &choiceExpr{
-								pos: position{line: 345, col: 15, offset: 7995},
+								pos: position{line: 345, col: 15, offset: 7996},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 345, col: 15, offset: 7995},
+										pos:  position{line: 345, col: 15, offset: 7996},
 										name: "Letter",
 									},
 									&litMatcher{
-										pos:        position{line: 345, col: 24, offset: 8004},
+										pos:        position{line: 345, col: 24, offset: 8005},
 										val:        "_",
 										ignoreCase: false,
 									},
@@ -1783,20 +1783,20 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 345, col: 30, offset: 8010},
+							pos: position{line: 345, col: 30, offset: 8011},
 							expr: &choiceExpr{
-								pos: position{line: 345, col: 31, offset: 8011},
+								pos: position{line: 345, col: 31, offset: 8012},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 345, col: 31, offset: 8011},
+										pos:  position{line: 345, col: 31, offset: 8012},
 										name: "Letter",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 345, col: 40, offset: 8020},
+										pos:  position{line: 345, col: 40, offset: 8021},
 										name: "Digit",
 									},
 									&charClassMatcher{
-										pos:        position{line: 345, col: 48, offset: 8028},
+										pos:        position{line: 345, col: 48, offset: 8029},
 										val:        "[._]",
 										chars:      []rune{'.', '_'},
 										ignoreCase: false,
@@ -1811,9 +1811,9 @@ var g = &grammar{
 		},
 		{
 			name: "ListSeparator",
-			pos:  position{line: 349, col: 1, offset: 8080},
+			pos:  position{line: 349, col: 1, offset: 8081},
 			expr: &charClassMatcher{
-				pos:        position{line: 349, col: 17, offset: 8098},
+				pos:        position{line: 349, col: 17, offset: 8099},
 				val:        "[,;]",
 				chars:      []rune{',', ';'},
 				ignoreCase: false,
@@ -1822,9 +1822,9 @@ var g = &grammar{
 		},
 		{
 			name: "Letter",
-			pos:  position{line: 350, col: 1, offset: 8103},
+			pos:  position{line: 350, col: 1, offset: 8104},
 			expr: &charClassMatcher{
-				pos:        position{line: 350, col: 10, offset: 8114},
+				pos:        position{line: 350, col: 10, offset: 8115},
 				val:        "[A-Za-z]",
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
 				ignoreCase: false,
@@ -1833,9 +1833,9 @@ var g = &grammar{
 		},
 		{
 			name: "Digit",
-			pos:  position{line: 351, col: 1, offset: 8123},
+			pos:  position{line: 351, col: 1, offset: 8124},
 			expr: &charClassMatcher{
-				pos:        position{line: 351, col: 9, offset: 8133},
+				pos:        position{line: 351, col: 9, offset: 8134},
 				val:        "[0-9]",
 				ranges:     []rune{'0', '9'},
 				ignoreCase: false,
@@ -1844,23 +1844,23 @@ var g = &grammar{
 		},
 		{
 			name: "SourceChar",
-			pos:  position{line: 355, col: 1, offset: 8144},
+			pos:  position{line: 355, col: 1, offset: 8145},
 			expr: &anyMatcher{
-				line: 355, col: 14, offset: 8159,
+				line: 355, col: 14, offset: 8160,
 			},
 		},
 		{
 			name: "Comment",
-			pos:  position{line: 356, col: 1, offset: 8161},
+			pos:  position{line: 356, col: 1, offset: 8162},
 			expr: &choiceExpr{
-				pos: position{line: 356, col: 11, offset: 8173},
+				pos: position{line: 356, col: 11, offset: 8174},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 356, col: 11, offset: 8173},
+						pos:  position{line: 356, col: 11, offset: 8174},
 						name: "MultiLineComment",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 356, col: 30, offset: 8192},
+						pos:  position{line: 356, col: 30, offset: 8193},
 						name: "SingleLineComment",
 					},
 				},
@@ -1868,37 +1868,37 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 357, col: 1, offset: 8210},
+			pos:  position{line: 357, col: 1, offset: 8211},
 			expr: &seqExpr{
-				pos: position{line: 357, col: 20, offset: 8231},
+				pos: position{line: 357, col: 20, offset: 8232},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 357, col: 20, offset: 8231},
+						pos:        position{line: 357, col: 20, offset: 8232},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 357, col: 25, offset: 8236},
+						pos: position{line: 357, col: 25, offset: 8237},
 						expr: &seqExpr{
-							pos: position{line: 357, col: 27, offset: 8238},
+							pos: position{line: 357, col: 27, offset: 8239},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 357, col: 27, offset: 8238},
+									pos: position{line: 357, col: 27, offset: 8239},
 									expr: &litMatcher{
-										pos:        position{line: 357, col: 28, offset: 8239},
+										pos:        position{line: 357, col: 28, offset: 8240},
 										val:        "*/",
 										ignoreCase: false,
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 357, col: 33, offset: 8244},
+									pos:  position{line: 357, col: 33, offset: 8245},
 									name: "SourceChar",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 357, col: 47, offset: 8258},
+						pos:        position{line: 357, col: 47, offset: 8259},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -1907,46 +1907,46 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineCommentNoLineTerminator",
-			pos:  position{line: 358, col: 1, offset: 8263},
+			pos:  position{line: 358, col: 1, offset: 8264},
 			expr: &seqExpr{
-				pos: position{line: 358, col: 36, offset: 8300},
+				pos: position{line: 358, col: 36, offset: 8301},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 358, col: 36, offset: 8300},
+						pos:        position{line: 358, col: 36, offset: 8301},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 358, col: 41, offset: 8305},
+						pos: position{line: 358, col: 41, offset: 8306},
 						expr: &seqExpr{
-							pos: position{line: 358, col: 43, offset: 8307},
+							pos: position{line: 358, col: 43, offset: 8308},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 358, col: 43, offset: 8307},
+									pos: position{line: 358, col: 43, offset: 8308},
 									expr: &choiceExpr{
-										pos: position{line: 358, col: 46, offset: 8310},
+										pos: position{line: 358, col: 46, offset: 8311},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 358, col: 46, offset: 8310},
+												pos:        position{line: 358, col: 46, offset: 8311},
 												val:        "*/",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 358, col: 53, offset: 8317},
+												pos:  position{line: 358, col: 53, offset: 8318},
 												name: "EOL",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 358, col: 59, offset: 8323},
+									pos:  position{line: 358, col: 59, offset: 8324},
 									name: "SourceChar",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 358, col: 73, offset: 8337},
+						pos:        position{line: 358, col: 73, offset: 8338},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -1955,32 +1955,32 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 359, col: 1, offset: 8342},
+			pos:  position{line: 359, col: 1, offset: 8343},
 			expr: &choiceExpr{
-				pos: position{line: 359, col: 21, offset: 8364},
+				pos: position{line: 359, col: 21, offset: 8365},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 359, col: 22, offset: 8365},
+						pos: position{line: 359, col: 22, offset: 8366},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 359, col: 22, offset: 8365},
+								pos:        position{line: 359, col: 22, offset: 8366},
 								val:        "//",
 								ignoreCase: false,
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 359, col: 27, offset: 8370},
+								pos: position{line: 359, col: 27, offset: 8371},
 								expr: &seqExpr{
-									pos: position{line: 359, col: 29, offset: 8372},
+									pos: position{line: 359, col: 29, offset: 8373},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 359, col: 29, offset: 8372},
+											pos: position{line: 359, col: 29, offset: 8373},
 											expr: &ruleRefExpr{
-												pos:  position{line: 359, col: 30, offset: 8373},
+												pos:  position{line: 359, col: 30, offset: 8374},
 												name: "EOL",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 359, col: 34, offset: 8377},
+											pos:  position{line: 359, col: 34, offset: 8378},
 											name: "SourceChar",
 										},
 									},
@@ -1989,27 +1989,27 @@ var g = &grammar{
 						},
 					},
 					&seqExpr{
-						pos: position{line: 359, col: 52, offset: 8395},
+						pos: position{line: 359, col: 52, offset: 8396},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 359, col: 52, offset: 8395},
+								pos:        position{line: 359, col: 52, offset: 8396},
 								val:        "#",
 								ignoreCase: false,
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 359, col: 56, offset: 8399},
+								pos: position{line: 359, col: 56, offset: 8400},
 								expr: &seqExpr{
-									pos: position{line: 359, col: 58, offset: 8401},
+									pos: position{line: 359, col: 58, offset: 8402},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 359, col: 58, offset: 8401},
+											pos: position{line: 359, col: 58, offset: 8402},
 											expr: &ruleRefExpr{
-												pos:  position{line: 359, col: 59, offset: 8402},
+												pos:  position{line: 359, col: 59, offset: 8403},
 												name: "EOL",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 359, col: 63, offset: 8406},
+											pos:  position{line: 359, col: 63, offset: 8407},
 											name: "SourceChar",
 										},
 									},
@@ -2022,22 +2022,22 @@ var g = &grammar{
 		},
 		{
 			name: "__",
-			pos:  position{line: 361, col: 1, offset: 8422},
+			pos:  position{line: 361, col: 1, offset: 8423},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 361, col: 6, offset: 8429},
+				pos: position{line: 361, col: 6, offset: 8430},
 				expr: &choiceExpr{
-					pos: position{line: 361, col: 8, offset: 8431},
+					pos: position{line: 361, col: 8, offset: 8432},
 					alternatives: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 361, col: 8, offset: 8431},
+							pos:  position{line: 361, col: 8, offset: 8432},
 							name: "Whitespace",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 361, col: 21, offset: 8444},
+							pos:  position{line: 361, col: 21, offset: 8445},
 							name: "EOL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 361, col: 27, offset: 8450},
+							pos:  position{line: 361, col: 27, offset: 8451},
 							name: "Comment",
 						},
 					},
@@ -2046,18 +2046,18 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 362, col: 1, offset: 8461},
+			pos:  position{line: 362, col: 1, offset: 8462},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 362, col: 5, offset: 8467},
+				pos: position{line: 362, col: 5, offset: 8468},
 				expr: &choiceExpr{
-					pos: position{line: 362, col: 7, offset: 8469},
+					pos: position{line: 362, col: 7, offset: 8470},
 					alternatives: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 362, col: 7, offset: 8469},
+							pos:  position{line: 362, col: 7, offset: 8470},
 							name: "Whitespace",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 362, col: 20, offset: 8482},
+							pos:  position{line: 362, col: 20, offset: 8483},
 							name: "MultiLineCommentNoLineTerminator",
 						},
 					},
@@ -2066,20 +2066,20 @@ var g = &grammar{
 		},
 		{
 			name: "WS",
-			pos:  position{line: 363, col: 1, offset: 8518},
+			pos:  position{line: 363, col: 1, offset: 8519},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 363, col: 6, offset: 8525},
+				pos: position{line: 363, col: 6, offset: 8526},
 				expr: &ruleRefExpr{
-					pos:  position{line: 363, col: 6, offset: 8525},
+					pos:  position{line: 363, col: 6, offset: 8526},
 					name: "Whitespace",
 				},
 			},
 		},
 		{
 			name: "Whitespace",
-			pos:  position{line: 365, col: 1, offset: 8538},
+			pos:  position{line: 365, col: 1, offset: 8539},
 			expr: &charClassMatcher{
-				pos:        position{line: 365, col: 14, offset: 8553},
+				pos:        position{line: 365, col: 14, offset: 8554},
 				val:        "[ \\t\\r]",
 				chars:      []rune{' ', '\t', '\r'},
 				ignoreCase: false,
@@ -2088,62 +2088,62 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 366, col: 1, offset: 8561},
+			pos:  position{line: 366, col: 1, offset: 8562},
 			expr: &litMatcher{
-				pos:        position{line: 366, col: 7, offset: 8569},
+				pos:        position{line: 366, col: 7, offset: 8570},
 				val:        "\n",
 				ignoreCase: false,
 			},
 		},
 		{
 			name: "EOS",
-			pos:  position{line: 367, col: 1, offset: 8574},
+			pos:  position{line: 367, col: 1, offset: 8575},
 			expr: &choiceExpr{
-				pos: position{line: 367, col: 7, offset: 8582},
+				pos: position{line: 367, col: 7, offset: 8583},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 367, col: 7, offset: 8582},
+						pos: position{line: 367, col: 7, offset: 8583},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 367, col: 7, offset: 8582},
+								pos:  position{line: 367, col: 7, offset: 8583},
 								name: "__",
 							},
 							&litMatcher{
-								pos:        position{line: 367, col: 10, offset: 8585},
+								pos:        position{line: 367, col: 10, offset: 8586},
 								val:        ";",
 								ignoreCase: false,
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 367, col: 16, offset: 8591},
+						pos: position{line: 367, col: 16, offset: 8592},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 367, col: 16, offset: 8591},
+								pos:  position{line: 367, col: 16, offset: 8592},
 								name: "_",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 367, col: 18, offset: 8593},
+								pos: position{line: 367, col: 18, offset: 8594},
 								expr: &ruleRefExpr{
-									pos:  position{line: 367, col: 18, offset: 8593},
+									pos:  position{line: 367, col: 18, offset: 8594},
 									name: "SingleLineComment",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 367, col: 37, offset: 8612},
+								pos:  position{line: 367, col: 37, offset: 8613},
 								name: "EOL",
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 367, col: 43, offset: 8618},
+						pos: position{line: 367, col: 43, offset: 8619},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 367, col: 43, offset: 8618},
+								pos:  position{line: 367, col: 43, offset: 8619},
 								name: "__",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 367, col: 46, offset: 8621},
+								pos:  position{line: 367, col: 46, offset: 8622},
 								name: "EOF",
 							},
 						},
@@ -2153,11 +2153,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 369, col: 1, offset: 8626},
+			pos:  position{line: 369, col: 1, offset: 8627},
 			expr: &notExpr{
-				pos: position{line: 369, col: 7, offset: 8634},
+				pos: position{line: 369, col: 7, offset: 8635},
 				expr: &anyMatcher{
-					line: 369, col: 8, offset: 8635,
+					line: 369, col: 8, offset: 8636,
 				},
 			},
 		},

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -26,7 +26,8 @@ func TestServiceParsing(t *testing.T) {
 		const string S2 = 'foo\'\tbar'
 		const list<i64> L = [1, 2, 3];
 
-		union myUnion {
+		union myUnion
+		{
 			1: double dbl = 1.1;
 			2: string str = "2";
 			3: i32 int32 = 3;
@@ -34,7 +35,14 @@ func TestServiceParsing(t *testing.T) {
 				= 5;
 		}
 
-		service ServiceNAME extends SomeBase {
+		enum Operation
+		{
+			ADD = 1,
+			SUBTRACT = 2
+		}
+
+		service ServiceNAME extends SomeBase
+		{
 			# authenticate method
 			// comment2
 			/* some other
@@ -163,6 +171,25 @@ func TestServiceParsing(t *testing.T) {
 		t.Errorf("myUnion missing")
 	} else if !reflect.DeepEqual(u, expectedUnion) {
 		t.Errorf("Expected\n%s\ngot\n%s", pprint(expectedUnion), pprint(u))
+	}
+
+	expectedEnum := &Enum{
+		Name: "Operation",
+		Values: map[string]*EnumValue{
+			"ADD": &EnumValue{
+				Name:  "ADD",
+				Value: 1,
+			},
+			"SUBTRACT": &EnumValue{
+				Name:  "SUBTRACT",
+				Value: 2,
+			},
+		},
+	}
+	if e := thrift.Enums["Operation"]; e == nil {
+		t.Errorf("enum Operation missing")
+	} else if !reflect.DeepEqual(e, expectedEnum) {
+		t.Errorf("Expected\n%s\ngot\n%s", pprint(expectedEnum), pprint(e))
 	}
 
 	if len(thrift.Services) != 1 {


### PR DESCRIPTION
Fix for parser failing on:
```thrift
enum Operator
{
}
```

but worked on
```thrift
enum Operator {
}
```