### PR TITLE
Reference fmt.Sprintf instead of fmt.Printf.

### DIFF
--- a/generator/go.go
+++ b/generator/go.go
@@ -602,7 +602,7 @@ func (g *GoGenerator) generateSingle(out io.Writer, thriftPath string, thrift *p
 		g.write(out, ")\n")
 	}
 
-	g.write(out, "\nvar _ = fmt.Printf\n")
+	g.write(out, "\nvar _ = fmt.Sprintf\n")
 
 	//
 


### PR DESCRIPTION
This is largely for aesthetic consistency, but we actually emit fmt.Sprintf
(vs fmt.Printf), so this reduces the number of unique external symbols that
are referenced by our generated code.