### PR TITLE
report invalid values separately from unsupported values 

### DIFF
--- a/thrift/encoder.go
+++ b/thrift/encoder.go
@@ -47,6 +47,9 @@ func (e *encoder) writeStruct(v reflect.Value) {
 		v = v.Elem()
 	}
 	if v.Kind() != reflect.Struct {
+		if !v.IsValid() {
+			e.error(&InvalidValueError{Value: v, Str: "expected a struct"})
+		}
 		e.error(&UnsupportedValueError{Value: v, Str: "expected a struct"})
 	}
 	if err := e.w.WriteStructBegin(v.Type().Name()); err != nil {

--- a/thrift/thrift.go
+++ b/thrift/thrift.go
@@ -96,6 +96,15 @@ func (e *UnsupportedValueError) Error() string {
 	return fmt.Sprintf("thrift: unsupported value (%+v): %s", e.Value, e.Str)
 }
 
+type InvalidValueError struct {
+	Value reflect.Value
+	Str   string
+}
+
+func (e *InvalidValueError) Error() string {
+	return fmt.Sprintf("thrift: invalid value (%+v): %s", e.Value, e.Str)
+}
+
 // ApplicationException is an application level thrift exception
 type ApplicationException struct {
 	Message string `thrift:"1"`


### PR DESCRIPTION
eg nil structs versus wrong type. I'm using this for quick.Check-based tests (ignoring input that isn't valid, such as slices of nil structs).