### PR TITLE
Fix extending services outside your package

### DIFF
--- a/generator/go.go
+++ b/generator/go.go
@@ -429,7 +429,7 @@ func (g *GoGenerator) writeService(out io.Writer, svc *parser.Service) error {
 
 	g.write(out, "\ntype %s interface {\n", svcName)
 	if svc.Extends != "" {
-		g.write(out, "\t%s\n", camelCase(svc.Extends))
+		g.write(out, "\t%s\n", svc.Extends)
 	}
 	methodNames := sortedKeys(svc.Methods)
 	for _, k := range methodNames {
@@ -446,7 +446,7 @@ func (g *GoGenerator) writeService(out io.Writer, svc *parser.Service) error {
 	if svc.Extends == "" {
 		g.write(out, "\ntype %sServer struct {\n\tImplementation %s\n}\n", svcName, svcName)
 	} else {
-		g.write(out, "\ntype %sServer struct {\n\t%sServer\n\tImplementation %s\n}\n", svcName, camelCase(svc.Extends), svcName)
+		g.write(out, "\ntype %sServer struct {\n\t%sServer\n\tImplementation %s\n}\n", svcName, svc.Extends, svcName)
 	}
 
 	// Server method wrappers
@@ -516,7 +516,7 @@ func (g *GoGenerator) writeService(out io.Writer, svc *parser.Service) error {
 	if svc.Extends == "" {
 		g.write(out, "\ntype %sClient struct {\n\tClient RPCClient\n}\n", svcName)
 	} else {
-		g.write(out, "\ntype %sClient struct {\n\t%sClient\n}\n", svcName, camelCase(svc.Extends))
+		g.write(out, "\ntype %sClient struct {\n\t%sClient\n}\n", svcName, svc.Extends)
 	}
 
 	for _, k := range methodNames {


### PR DESCRIPTION
I'm betting this doesn't work with extending services inside the same package, but I wanted to get your opinion on this before hacking that on (I'm guessing it should camel case after the '.' but not before). It feels like that pattern could be better supported inside camelCase itself.