### PR TITLE
Deterministic field ordering while encoding

### DIFF
--- a/thrift/encoder.go
+++ b/thrift/encoder.go
@@ -52,7 +52,10 @@ func (e *encoder) writeStruct(v reflect.Value) {
 	if err := e.w.WriteStructBegin(v.Type().Name()); err != nil {
 		e.error(err)
 	}
-	for _, ef := range encodeFields(v.Type()).fields {
+
+	mf := encodeFields(v.Type())
+	for _, fid := range mf.orderedIds {
+		ef := mf.fields[fid]
 		structField := v.Type().Field(ef.i)
 		fieldValue := v.Field(ef.i)
 

--- a/thrift/thrift.go
+++ b/thrift/thrift.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sort"
 	"sync"
 )
 
@@ -191,8 +192,9 @@ type encodeField struct {
 }
 
 type structMeta struct {
-	required uint64 // bitmap of required fields
-	fields   map[int]encodeField
+	required   uint64 // bitmap of required fields
+	orderedIds []int
+	fields     map[int]encodeField
 }
 
 var (
@@ -261,6 +263,13 @@ func encodeFields(t reflect.Type) structMeta {
 			fs[ef.id] = ef
 		}
 	}
+
+	m.orderedIds = make([]int, 0, len(m.fields))
+	for idx := range m.fields {
+		m.orderedIds = append(m.orderedIds, idx)
+	}
+	sort.Ints(m.orderedIds)
+
 	encodeFieldsCache[t] = m
 	return m
 }


### PR DESCRIPTION
It's pretty useful to have a fixed field ordering for tests, and this should be minimal cost.