### PR TITLE
Add support for annotations

### DIFF
--- a/generator/go.go
+++ b/generator/go.go
@@ -242,7 +242,7 @@ func (g *GoGenerator) formatKeyType(pkg string, thrift *parser.Thrift, typ *pars
 // Follow typedefs to the actual type
 func (g *GoGenerator) resolveType(typ *parser.Type) string {
 	if t := g.thrift.Typedefs[typ.Name]; t != nil {
-		return g.resolveType(t)
+		return g.resolveType(t.Type)
 	}
 	return typ.Name
 }
@@ -648,7 +648,7 @@ func (g *GoGenerator) generateSingle(out io.Writer, thriftPath string, thrift *p
 		g.write(out, "\n")
 		for _, k := range sortedKeys(thrift.Typedefs) {
 			t := thrift.Typedefs[k]
-			g.write(out, "type %s %s\n", camelCase(k), g.formatType(g.pkg, g.thrift, t, toNoPointer))
+			g.write(out, "type %s %s\n", camelCase(k), g.formatType(g.pkg, g.thrift, t.Type, toNoPointer))
 		}
 	}
 

--- a/parser/grammar.peg
+++ b/parser/grammar.peg
@@ -122,11 +122,12 @@ Const ← "const" _ typ:FieldType _ name:Identifier __ "=" __ value:ConstValue E
 	}, nil
 }
 
-Enum ← "enum" _ name:Identifier __ '{' __ values:(EnumValue __)* '}' EOS {
+Enum ← "enum" _ name:Identifier __ '{' __ values:(EnumValue __)* '}' __ annotations:TypeAnnotations? EOS {
 	vs := toIfaceSlice(values)
 	en := &Enum{
 		Name: string(name.(Identifier)),
 		Values: make(map[string]*EnumValue, len(vs)),
+		Annotations: toAnnotations(annotations),
 	}
 	// Assigns numbers in order. This will behave badly if some values are
 	// defined and other are not, but I think that's ok since that's a silly
@@ -145,10 +146,11 @@ Enum ← "enum" _ name:Identifier __ '{' __ values:(EnumValue __)* '}' EOS {
 	return en, nil
 }
 
-EnumValue ← name:Identifier _ value:('=' _ IntConstant)? TypeAnnotations? ListSeparator? {
+EnumValue ← name:Identifier _ value:('=' _ IntConstant)? __ annotations:TypeAnnotations? ListSeparator? {
 	ev := &EnumValue{
 		Name: string(name.(Identifier)),
 		Value: -1,
+		Annotations: toAnnotations(annotations),
 	}
 	if value != nil {
 		ev.Value = int(value.([]interface{})[2].(int64))

--- a/parser/grammar.peg
+++ b/parser/grammar.peg
@@ -14,11 +14,6 @@ type namespace struct {
 	namespace string
 }
 
-type typeDef struct {
-	name string
-	typ *Type
-}
-
 type exception *Struct
 
 type union *Struct
@@ -49,13 +44,20 @@ func unionToStruct(u union) *Struct {
 	}
 	return st
 }
+
+func toAnnotations(v interface{}) []*Annotation {
+	if v == nil {
+		return nil
+	}
+	return v.([]*Annotation)
+}
 }
 
 Grammar ← __ statements:( Statement __ )* (EOF / SyntaxError) {
 	thrift := &Thrift{
 		Includes: make(map[string]string),
 		Namespaces: make(map[string]string),
-		Typedefs: make(map[string]*Type),
+		Typedefs: make(map[string]*Typedef),
 		Constants: make(map[string]*Constant),
 		Enums: make(map[string]*Enum),
 		Structs: make(map[string]*Struct),
@@ -72,8 +74,8 @@ Grammar ← __ statements:( Statement __ )* (EOF / SyntaxError) {
 			thrift.Constants[v.Name] = v
 		case *Enum:
 			thrift.Enums[v.Name] = v
-		case *typeDef:
-			thrift.Typedefs[v.name] = v.typ
+		case *Typedef:
+			thrift.Typedefs[v.Alias] = v
 		case *Struct:
 			thrift.Structs[v.Name] = v
 		case exception:
@@ -143,7 +145,7 @@ Enum ← "enum" _ name:Identifier __ '{' __ values:(EnumValue __)* '}' EOS {
 	return en, nil
 }
 
-EnumValue ← name:Identifier _ value:('=' _ IntConstant)? ListSeparator? {
+EnumValue ← name:Identifier _ value:('=' _ IntConstant)? TypeAnnotations? ListSeparator? {
 	ev := &EnumValue{
 		Name: string(name.(Identifier)),
 		Value: -1,
@@ -154,10 +156,11 @@ EnumValue ← name:Identifier _ value:('=' _ IntConstant)? ListSeparator? {
 	return ev, nil
 }
 
-TypeDef ← "typedef" _ typ:FieldType _ name:Identifier EOS {
-	return &typeDef{
-		name: string(name.(Identifier)),
-		typ: typ.(*Type),
+TypeDef ← "typedef" _ typ:FieldType _ name:Identifier _ annotations:TypeAnnotations? EOS {
+	return &Typedef{
+		Type: typ.(*Type),
+		Alias: string(name.(Identifier)),
+		Annotations: toAnnotations(annotations),
 	}, nil
 }
 
@@ -266,33 +269,43 @@ DefinitionType ← typ:(BaseType / ContainerType) {
 	return typ, nil
 }
 
-BaseType ← ("bool" / "byte" / "i16" / "i32" / "i64" / "double" / "string" / "binary" ) {
-	return &Type{Name: string(c.text)}, nil
+BaseType ← name:BaseTypeName __ annotations:TypeAnnotations? {
+	return &Type{
+		Name: name.(string),
+		Annotations: toAnnotations(annotations),
+	}, nil
+}
+
+BaseTypeName ← ("bool" / "byte" / "i16" / "i32" / "i64" / "double" / "string" / "binary" ) {
+	return string(c.text), nil
 }
 
 ContainerType ← typ:(MapType / SetType / ListType) {
 	return typ, nil
 }
 
-MapType ← CppType? "map" WS "<" WS key:FieldType WS "," WS value:FieldType WS ">" {
+MapType ← CppType? "map" WS "<" WS key:FieldType WS "," WS value:FieldType WS ">" __ annotations:TypeAnnotations? {
 	return &Type{
 		Name: "map",
 		KeyType: key.(*Type),
 		ValueType: value.(*Type),
+		Annotations: toAnnotations(annotations),
 	}, nil
 }
 
-SetType ← CppType? "set" WS "<" WS typ:FieldType WS ">" {
+SetType ← CppType? "set" WS "<" WS typ:FieldType WS ">" __ annotations:TypeAnnotations? {
 	return &Type{
 		Name: "set",
 		ValueType: typ.(*Type),
+		Annotations: toAnnotations(annotations),
 	}, nil
 }
 
-ListType ← "list" WS "<" WS typ:FieldType WS ">" {
+ListType ← "list" WS "<" WS typ:FieldType WS ">" __ annotations:TypeAnnotations? {
 	return &Type{
 		Name: "list",
 		ValueType: typ.(*Type),
+		Annotations: toAnnotations(annotations),
 	}, nil
 }
 
@@ -301,6 +314,25 @@ CppType ← "cpp_type" cppType:Literal {
 }
 
 ConstValue ← Literal / DoubleConstant / IntConstant / ConstMap / ConstList / Identifier
+
+TypeAnnotations ← '(' __ annotations:TypeAnnotation* ')' {
+	var anns []*Annotation
+	for _, ann := range annotations.([]interface{}) {
+		anns = append(anns, ann.(*Annotation))
+	}
+	return anns, nil
+}
+
+TypeAnnotation ← name:Identifier _ value:('=' __ value:Literal { return value, nil })? ListSeparator? __ {
+	var optValue string
+	if value != nil {
+		optValue = value.(string)
+	}
+	return &Annotation{
+	  Name: string(name.(Identifier)),
+		Value: optValue,
+	}, nil
+}
 
 IntConstant ← [-+]? Digit+ {
 	return strconv.ParseInt(string(c.text), 10, 64)

--- a/parser/grammar.peg
+++ b/parser/grammar.peg
@@ -189,11 +189,12 @@ FieldList ← fields:(Field __)* {
 	return flds, nil
 }
 
-Field ← id:IntConstant _ ':' _ req:FieldReq? _ typ:FieldType _ name:Identifier __ def:('=' _ ConstValue)? ListSeparator? {
+Field ← id:IntConstant _ ':' _ req:FieldReq? _ typ:FieldType _ name:Identifier __ def:('=' _ ConstValue)? __ annotations:TypeAnnotations? ListSeparator? {
 	f := &Field{
 		ID       : int(id.(int64)),
 		Name     : string(name.(Identifier)),
 		Type     : typ.(*Type),
+		Annotations: toAnnotations(annotations),
 	}
 	if req != nil && !req.(bool) {
 		f.Optional = true

--- a/parser/grammar.peg
+++ b/parser/grammar.peg
@@ -122,7 +122,7 @@ Const ← "const" _ typ:FieldType _ name:Identifier __ "=" __ value:ConstValue E
 	}, nil
 }
 
-Enum ← "enum" _ name:Identifier __ '{' __ values:(EnumValue __)* '}' __ annotations:TypeAnnotations? EOS {
+Enum ← "enum" _ name:Identifier __ '{' __ values:(EnumValue __)* '}' _ annotations:TypeAnnotations? EOS {
 	vs := toIfaceSlice(values)
 	en := &Enum{
 		Name: string(name.(Identifier)),
@@ -146,7 +146,7 @@ Enum ← "enum" _ name:Identifier __ '{' __ values:(EnumValue __)* '}' __ annota
 	return en, nil
 }
 
-EnumValue ← name:Identifier _ value:('=' _ IntConstant)? __ annotations:TypeAnnotations? ListSeparator? {
+EnumValue ← name:Identifier _ value:('=' _ IntConstant)? _ annotations:TypeAnnotations? ListSeparator? {
 	ev := &EnumValue{
 		Name: string(name.(Identifier)),
 		Value: -1,
@@ -169,7 +169,7 @@ TypeDef ← "typedef" _ typ:FieldType _ name:Identifier _ annotations:TypeAnnota
 Struct ← "struct" _ st:StructLike { return st.(*Struct), nil }
 Exception ← "exception" _ st:StructLike { return exception(st.(*Struct)), nil }
 Union ← "union" _ st:StructLike { return union(st.(*Struct)), nil }
-StructLike ← name:Identifier __ '{' __ fields:FieldList '}' __ annotations:TypeAnnotations? EOS {
+StructLike ← name:Identifier __ '{' __ fields:FieldList '}' _ annotations:TypeAnnotations? EOS {
 	st := &Struct{
 		Name: string(name.(Identifier)),
 		Annotations: toAnnotations(annotations),
@@ -189,7 +189,7 @@ FieldList ← fields:(Field __)* {
 	return flds, nil
 }
 
-Field ← id:IntConstant _ ':' _ req:FieldReq? _ typ:FieldType _ name:Identifier __ def:('=' _ ConstValue)? __ annotations:TypeAnnotations? ListSeparator? {
+Field ← id:IntConstant _ ':' _ req:FieldReq? _ typ:FieldType _ name:Identifier __ def:('=' _ ConstValue)? _ annotations:TypeAnnotations? ListSeparator? {
 	f := &Field{
 		ID       : int(id.(int64)),
 		Name     : string(name.(Identifier)),
@@ -209,7 +209,7 @@ FieldReq ← ("required" / "optional") {
 	return !bytes.Equal(c.text, []byte("optional")), nil
 }
 
-Service ← "service" _ name:Identifier _ extends:("extends" __ Identifier __)? __ '{' __ methods:(Function __)* ('}' / EndOfServiceError) __ annotations:TypeAnnotations?  EOS {
+Service ← "service" _ name:Identifier _ extends:("extends" __ Identifier __)? __ '{' __ methods:(Function __)* ('}' / EndOfServiceError) _ annotations:TypeAnnotations?  EOS {
 	ms := methods.([]interface{})
 	svc := &Service{
 		Name: string(name.(Identifier)),
@@ -229,7 +229,7 @@ EndOfServiceError ← . {
 	return nil, errors.New("parser: expected end of service")
 }
 
-Function ← oneway:("oneway" __)? typ:FunctionType __ name:Identifier _ '(' __ arguments:FieldList ')' __ exceptions:Throws? __ annotations:TypeAnnotations? ListSeparator? {
+Function ← oneway:("oneway" __)? typ:FunctionType __ name:Identifier _ '(' __ arguments:FieldList ')' __ exceptions:Throws? _ annotations:TypeAnnotations? ListSeparator? {
 	m := &Method{
 		Name: string(name.(Identifier)),
 		Annotations: toAnnotations(annotations),
@@ -275,7 +275,7 @@ DefinitionType ← typ:(BaseType / ContainerType) {
 	return typ, nil
 }
 
-BaseType ← name:BaseTypeName __ annotations:TypeAnnotations? {
+BaseType ← name:BaseTypeName _ annotations:TypeAnnotations? {
 	return &Type{
 		Name: name.(string),
 		Annotations: toAnnotations(annotations),
@@ -290,7 +290,7 @@ ContainerType ← typ:(MapType / SetType / ListType) {
 	return typ, nil
 }
 
-MapType ← CppType? "map" WS "<" WS key:FieldType WS "," WS value:FieldType WS ">" __ annotations:TypeAnnotations? {
+MapType ← CppType? "map" WS "<" WS key:FieldType WS "," WS value:FieldType WS ">" _ annotations:TypeAnnotations? {
 	return &Type{
 		Name: "map",
 		KeyType: key.(*Type),
@@ -299,7 +299,7 @@ MapType ← CppType? "map" WS "<" WS key:FieldType WS "," WS value:FieldType WS 
 	}, nil
 }
 
-SetType ← CppType? "set" WS "<" WS typ:FieldType WS ">" __ annotations:TypeAnnotations? {
+SetType ← CppType? "set" WS "<" WS typ:FieldType WS ">" _ annotations:TypeAnnotations? {
 	return &Type{
 		Name: "set",
 		ValueType: typ.(*Type),
@@ -307,7 +307,7 @@ SetType ← CppType? "set" WS "<" WS typ:FieldType WS ">" __ annotations:TypeAnn
 	}, nil
 }
 
-ListType ← "list" WS "<" WS typ:FieldType WS ">" __ annotations:TypeAnnotations? {
+ListType ← "list" WS "<" WS typ:FieldType WS ">" _ annotations:TypeAnnotations? {
 	return &Type{
 		Name: "list",
 		ValueType: typ.(*Type),

--- a/parser/grammar.peg
+++ b/parser/grammar.peg
@@ -169,9 +169,10 @@ TypeDef ← "typedef" _ typ:FieldType _ name:Identifier _ annotations:TypeAnnota
 Struct ← "struct" _ st:StructLike { return st.(*Struct), nil }
 Exception ← "exception" _ st:StructLike { return exception(st.(*Struct)), nil }
 Union ← "union" _ st:StructLike { return union(st.(*Struct)), nil }
-StructLike ← name:Identifier __ '{' __ fields:FieldList '}' EOS {
+StructLike ← name:Identifier __ '{' __ fields:FieldList '}' __ annotations:TypeAnnotations? EOS {
 	st := &Struct{
 		Name: string(name.(Identifier)),
+		Annotations: toAnnotations(annotations),
 	}
 	if fields != nil {
 		st.Fields = fields.([]*Field)

--- a/parser/grammar.peg
+++ b/parser/grammar.peg
@@ -208,11 +208,12 @@ FieldReq ← ("required" / "optional") {
 	return !bytes.Equal(c.text, []byte("optional")), nil
 }
 
-Service ← "service" _ name:Identifier _ extends:("extends" __ Identifier __)? __ '{' __ methods:(Function __)* ('}' / EndOfServiceError) EOS {
+Service ← "service" _ name:Identifier _ extends:("extends" __ Identifier __)? __ '{' __ methods:(Function __)* ('}' / EndOfServiceError) __ annotations:TypeAnnotations?  EOS {
 	ms := methods.([]interface{})
 	svc := &Service{
 		Name: string(name.(Identifier)),
 		Methods: make(map[string]*Method, len(ms)),
+		Annotations: toAnnotations(annotations),
 	}
 	if extends != nil {
 		svc.Extends = string(extends.([]interface{})[2].(Identifier))
@@ -227,9 +228,10 @@ EndOfServiceError ← . {
 	return nil, errors.New("parser: expected end of service")
 }
 
-Function ← oneway:("oneway" __)? typ:FunctionType __ name:Identifier _ '(' __ arguments:FieldList ')' __ exceptions:Throws? ListSeparator? {
+Function ← oneway:("oneway" __)? typ:FunctionType __ name:Identifier _ '(' __ arguments:FieldList ')' __ exceptions:Throws? __ annotations:TypeAnnotations? ListSeparator? {
 	m := &Method{
 		Name: string(name.(Identifier)),
+		Annotations: toAnnotations(annotations),
 	}
 	t := typ.(*Type)
 	if t.Name != "void" {

--- a/parser/grammar.peg.go
+++ b/parser/grammar.peg.go
@@ -676,6 +676,21 @@ var g = &grammar{
 						},
 						&ruleRefExpr{
 							pos:  position{line: 173, col: 61, offset: 4167},
+							name: "__",
+						},
+						&labeledExpr{
+							pos:   position{line: 173, col: 64, offset: 4170},
+							label: "annotations",
+							expr: &zeroOrOneExpr{
+								pos: position{line: 173, col: 76, offset: 4182},
+								expr: &ruleRefExpr{
+									pos:  position{line: 173, col: 76, offset: 4182},
+									name: "TypeAnnotations",
+								},
+							},
+						},
+						&ruleRefExpr{
+							pos:  position{line: 173, col: 93, offset: 4199},
 							name: "EOS",
 						},
 					},
@@ -684,24 +699,24 @@ var g = &grammar{
 		},
 		{
 			name: "FieldList",
-			pos:  position{line: 183, col: 1, offset: 4301},
+			pos:  position{line: 184, col: 1, offset: 4376},
 			expr: &actionExpr{
-				pos: position{line: 183, col: 13, offset: 4315},
+				pos: position{line: 184, col: 13, offset: 4390},
 				run: (*parser).callonFieldList1,
 				expr: &labeledExpr{
-					pos:   position{line: 183, col: 13, offset: 4315},
+					pos:   position{line: 184, col: 13, offset: 4390},
 					label: "fields",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 183, col: 20, offset: 4322},
+						pos: position{line: 184, col: 20, offset: 4397},
 						expr: &seqExpr{
-							pos: position{line: 183, col: 21, offset: 4323},
+							pos: position{line: 184, col: 21, offset: 4398},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 183, col: 21, offset: 4323},
+									pos:  position{line: 184, col: 21, offset: 4398},
 									name: "Field",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 183, col: 27, offset: 4329},
+									pos:  position{line: 184, col: 27, offset: 4404},
 									name: "__",
 								},
 							},
@@ -712,92 +727,92 @@ var g = &grammar{
 		},
 		{
 			name: "Field",
-			pos:  position{line: 192, col: 1, offset: 4489},
+			pos:  position{line: 193, col: 1, offset: 4564},
 			expr: &actionExpr{
-				pos: position{line: 192, col: 9, offset: 4499},
+				pos: position{line: 193, col: 9, offset: 4574},
 				run: (*parser).callonField1,
 				expr: &seqExpr{
-					pos: position{line: 192, col: 9, offset: 4499},
+					pos: position{line: 193, col: 9, offset: 4574},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 192, col: 9, offset: 4499},
+							pos:   position{line: 193, col: 9, offset: 4574},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 192, col: 12, offset: 4502},
+								pos:  position{line: 193, col: 12, offset: 4577},
 								name: "IntConstant",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 192, col: 24, offset: 4514},
+							pos:  position{line: 193, col: 24, offset: 4589},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 192, col: 26, offset: 4516},
+							pos:        position{line: 193, col: 26, offset: 4591},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 192, col: 30, offset: 4520},
+							pos:  position{line: 193, col: 30, offset: 4595},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 192, col: 32, offset: 4522},
+							pos:   position{line: 193, col: 32, offset: 4597},
 							label: "req",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 192, col: 36, offset: 4526},
+								pos: position{line: 193, col: 36, offset: 4601},
 								expr: &ruleRefExpr{
-									pos:  position{line: 192, col: 36, offset: 4526},
+									pos:  position{line: 193, col: 36, offset: 4601},
 									name: "FieldReq",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 192, col: 46, offset: 4536},
+							pos:  position{line: 193, col: 46, offset: 4611},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 192, col: 48, offset: 4538},
+							pos:   position{line: 193, col: 48, offset: 4613},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 192, col: 52, offset: 4542},
+								pos:  position{line: 193, col: 52, offset: 4617},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 192, col: 62, offset: 4552},
+							pos:  position{line: 193, col: 62, offset: 4627},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 192, col: 64, offset: 4554},
+							pos:   position{line: 193, col: 64, offset: 4629},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 192, col: 69, offset: 4559},
+								pos:  position{line: 193, col: 69, offset: 4634},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 192, col: 80, offset: 4570},
+							pos:  position{line: 193, col: 80, offset: 4645},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 192, col: 83, offset: 4573},
+							pos:   position{line: 193, col: 83, offset: 4648},
 							label: "def",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 192, col: 87, offset: 4577},
+								pos: position{line: 193, col: 87, offset: 4652},
 								expr: &seqExpr{
-									pos: position{line: 192, col: 88, offset: 4578},
+									pos: position{line: 193, col: 88, offset: 4653},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 192, col: 88, offset: 4578},
+											pos:        position{line: 193, col: 88, offset: 4653},
 											val:        "=",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 192, col: 92, offset: 4582},
+											pos:  position{line: 193, col: 92, offset: 4657},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 192, col: 94, offset: 4584},
+											pos:  position{line: 193, col: 94, offset: 4659},
 											name: "ConstValue",
 										},
 									},
@@ -805,9 +820,9 @@ var g = &grammar{
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 192, col: 107, offset: 4597},
+							pos: position{line: 193, col: 107, offset: 4672},
 							expr: &ruleRefExpr{
-								pos:  position{line: 192, col: 107, offset: 4597},
+								pos:  position{line: 193, col: 107, offset: 4672},
 								name: "ListSeparator",
 							},
 						},
@@ -817,20 +832,20 @@ var g = &grammar{
 		},
 		{
 			name: "FieldReq",
-			pos:  position{line: 207, col: 1, offset: 4857},
+			pos:  position{line: 208, col: 1, offset: 4932},
 			expr: &actionExpr{
-				pos: position{line: 207, col: 12, offset: 4870},
+				pos: position{line: 208, col: 12, offset: 4945},
 				run: (*parser).callonFieldReq1,
 				expr: &choiceExpr{
-					pos: position{line: 207, col: 13, offset: 4871},
+					pos: position{line: 208, col: 13, offset: 4946},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 207, col: 13, offset: 4871},
+							pos:        position{line: 208, col: 13, offset: 4946},
 							val:        "required",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 207, col: 26, offset: 4884},
+							pos:        position{line: 208, col: 26, offset: 4959},
 							val:        "optional",
 							ignoreCase: false,
 						},
@@ -840,57 +855,57 @@ var g = &grammar{
 		},
 		{
 			name: "Service",
-			pos:  position{line: 211, col: 1, offset: 4955},
+			pos:  position{line: 212, col: 1, offset: 5030},
 			expr: &actionExpr{
-				pos: position{line: 211, col: 11, offset: 4967},
+				pos: position{line: 212, col: 11, offset: 5042},
 				run: (*parser).callonService1,
 				expr: &seqExpr{
-					pos: position{line: 211, col: 11, offset: 4967},
+					pos: position{line: 212, col: 11, offset: 5042},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 211, col: 11, offset: 4967},
+							pos:        position{line: 212, col: 11, offset: 5042},
 							val:        "service",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 211, col: 21, offset: 4977},
+							pos:  position{line: 212, col: 21, offset: 5052},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 211, col: 23, offset: 4979},
+							pos:   position{line: 212, col: 23, offset: 5054},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 211, col: 28, offset: 4984},
+								pos:  position{line: 212, col: 28, offset: 5059},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 211, col: 39, offset: 4995},
+							pos:  position{line: 212, col: 39, offset: 5070},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 211, col: 41, offset: 4997},
+							pos:   position{line: 212, col: 41, offset: 5072},
 							label: "extends",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 211, col: 49, offset: 5005},
+								pos: position{line: 212, col: 49, offset: 5080},
 								expr: &seqExpr{
-									pos: position{line: 211, col: 50, offset: 5006},
+									pos: position{line: 212, col: 50, offset: 5081},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 211, col: 50, offset: 5006},
+											pos:        position{line: 212, col: 50, offset: 5081},
 											val:        "extends",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 211, col: 60, offset: 5016},
+											pos:  position{line: 212, col: 60, offset: 5091},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 211, col: 63, offset: 5019},
+											pos:  position{line: 212, col: 63, offset: 5094},
 											name: "Identifier",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 211, col: 74, offset: 5030},
+											pos:  position{line: 212, col: 74, offset: 5105},
 											name: "__",
 										},
 									},
@@ -898,32 +913,32 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 211, col: 79, offset: 5035},
+							pos:  position{line: 212, col: 79, offset: 5110},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 211, col: 82, offset: 5038},
+							pos:        position{line: 212, col: 82, offset: 5113},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 211, col: 86, offset: 5042},
+							pos:  position{line: 212, col: 86, offset: 5117},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 211, col: 89, offset: 5045},
+							pos:   position{line: 212, col: 89, offset: 5120},
 							label: "methods",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 211, col: 97, offset: 5053},
+								pos: position{line: 212, col: 97, offset: 5128},
 								expr: &seqExpr{
-									pos: position{line: 211, col: 98, offset: 5054},
+									pos: position{line: 212, col: 98, offset: 5129},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 211, col: 98, offset: 5054},
+											pos:  position{line: 212, col: 98, offset: 5129},
 											name: "Function",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 211, col: 107, offset: 5063},
+											pos:  position{line: 212, col: 107, offset: 5138},
 											name: "__",
 										},
 									},
@@ -931,21 +946,21 @@ var g = &grammar{
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 211, col: 113, offset: 5069},
+							pos: position{line: 212, col: 113, offset: 5144},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 211, col: 113, offset: 5069},
+									pos:        position{line: 212, col: 113, offset: 5144},
 									val:        "}",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 211, col: 119, offset: 5075},
+									pos:  position{line: 212, col: 119, offset: 5150},
 									name: "EndOfServiceError",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 211, col: 138, offset: 5094},
+							pos:  position{line: 212, col: 138, offset: 5169},
 							name: "EOS",
 						},
 					},
@@ -954,39 +969,39 @@ var g = &grammar{
 		},
 		{
 			name: "EndOfServiceError",
-			pos:  position{line: 226, col: 1, offset: 5435},
+			pos:  position{line: 227, col: 1, offset: 5510},
 			expr: &actionExpr{
-				pos: position{line: 226, col: 21, offset: 5457},
+				pos: position{line: 227, col: 21, offset: 5532},
 				run: (*parser).callonEndOfServiceError1,
 				expr: &anyMatcher{
-					line: 226, col: 21, offset: 5457,
+					line: 227, col: 21, offset: 5532,
 				},
 			},
 		},
 		{
 			name: "Function",
-			pos:  position{line: 230, col: 1, offset: 5523},
+			pos:  position{line: 231, col: 1, offset: 5598},
 			expr: &actionExpr{
-				pos: position{line: 230, col: 12, offset: 5536},
+				pos: position{line: 231, col: 12, offset: 5611},
 				run: (*parser).callonFunction1,
 				expr: &seqExpr{
-					pos: position{line: 230, col: 12, offset: 5536},
+					pos: position{line: 231, col: 12, offset: 5611},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 230, col: 12, offset: 5536},
+							pos:   position{line: 231, col: 12, offset: 5611},
 							label: "oneway",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 230, col: 19, offset: 5543},
+								pos: position{line: 231, col: 19, offset: 5618},
 								expr: &seqExpr{
-									pos: position{line: 230, col: 20, offset: 5544},
+									pos: position{line: 231, col: 20, offset: 5619},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 230, col: 20, offset: 5544},
+											pos:        position{line: 231, col: 20, offset: 5619},
 											val:        "oneway",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 230, col: 29, offset: 5553},
+											pos:  position{line: 231, col: 29, offset: 5628},
 											name: "__",
 										},
 									},
@@ -994,70 +1009,70 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 230, col: 34, offset: 5558},
+							pos:   position{line: 231, col: 34, offset: 5633},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 230, col: 38, offset: 5562},
+								pos:  position{line: 231, col: 38, offset: 5637},
 								name: "FunctionType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 230, col: 51, offset: 5575},
+							pos:  position{line: 231, col: 51, offset: 5650},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 230, col: 54, offset: 5578},
+							pos:   position{line: 231, col: 54, offset: 5653},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 230, col: 59, offset: 5583},
+								pos:  position{line: 231, col: 59, offset: 5658},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 230, col: 70, offset: 5594},
+							pos:  position{line: 231, col: 70, offset: 5669},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 230, col: 72, offset: 5596},
+							pos:        position{line: 231, col: 72, offset: 5671},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 230, col: 76, offset: 5600},
+							pos:  position{line: 231, col: 76, offset: 5675},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 230, col: 79, offset: 5603},
+							pos:   position{line: 231, col: 79, offset: 5678},
 							label: "arguments",
 							expr: &ruleRefExpr{
-								pos:  position{line: 230, col: 89, offset: 5613},
+								pos:  position{line: 231, col: 89, offset: 5688},
 								name: "FieldList",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 230, col: 99, offset: 5623},
+							pos:        position{line: 231, col: 99, offset: 5698},
 							val:        ")",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 230, col: 103, offset: 5627},
+							pos:  position{line: 231, col: 103, offset: 5702},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 230, col: 106, offset: 5630},
+							pos:   position{line: 231, col: 106, offset: 5705},
 							label: "exceptions",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 230, col: 117, offset: 5641},
+								pos: position{line: 231, col: 117, offset: 5716},
 								expr: &ruleRefExpr{
-									pos:  position{line: 230, col: 117, offset: 5641},
+									pos:  position{line: 231, col: 117, offset: 5716},
 									name: "Throws",
 								},
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 230, col: 125, offset: 5649},
+							pos: position{line: 231, col: 125, offset: 5724},
 							expr: &ruleRefExpr{
-								pos:  position{line: 230, col: 125, offset: 5649},
+								pos:  position{line: 231, col: 125, offset: 5724},
 								name: "ListSeparator",
 							},
 						},
@@ -1067,23 +1082,23 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionType",
-			pos:  position{line: 253, col: 1, offset: 6030},
+			pos:  position{line: 254, col: 1, offset: 6105},
 			expr: &actionExpr{
-				pos: position{line: 253, col: 16, offset: 6047},
+				pos: position{line: 254, col: 16, offset: 6122},
 				run: (*parser).callonFunctionType1,
 				expr: &labeledExpr{
-					pos:   position{line: 253, col: 16, offset: 6047},
+					pos:   position{line: 254, col: 16, offset: 6122},
 					label: "typ",
 					expr: &choiceExpr{
-						pos: position{line: 253, col: 21, offset: 6052},
+						pos: position{line: 254, col: 21, offset: 6127},
 						alternatives: []interface{}{
 							&litMatcher{
-								pos:        position{line: 253, col: 21, offset: 6052},
+								pos:        position{line: 254, col: 21, offset: 6127},
 								val:        "void",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 253, col: 30, offset: 6061},
+								pos:  position{line: 254, col: 30, offset: 6136},
 								name: "FieldType",
 							},
 						},
@@ -1093,41 +1108,41 @@ var g = &grammar{
 		},
 		{
 			name: "Throws",
-			pos:  position{line: 260, col: 1, offset: 6168},
+			pos:  position{line: 261, col: 1, offset: 6243},
 			expr: &actionExpr{
-				pos: position{line: 260, col: 10, offset: 6179},
+				pos: position{line: 261, col: 10, offset: 6254},
 				run: (*parser).callonThrows1,
 				expr: &seqExpr{
-					pos: position{line: 260, col: 10, offset: 6179},
+					pos: position{line: 261, col: 10, offset: 6254},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 260, col: 10, offset: 6179},
+							pos:        position{line: 261, col: 10, offset: 6254},
 							val:        "throws",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 260, col: 19, offset: 6188},
+							pos:  position{line: 261, col: 19, offset: 6263},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 260, col: 22, offset: 6191},
+							pos:        position{line: 261, col: 22, offset: 6266},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 260, col: 26, offset: 6195},
+							pos:  position{line: 261, col: 26, offset: 6270},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 260, col: 29, offset: 6198},
+							pos:   position{line: 261, col: 29, offset: 6273},
 							label: "exceptions",
 							expr: &ruleRefExpr{
-								pos:  position{line: 260, col: 40, offset: 6209},
+								pos:  position{line: 261, col: 40, offset: 6284},
 								name: "FieldList",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 260, col: 50, offset: 6219},
+							pos:        position{line: 261, col: 50, offset: 6294},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -1137,26 +1152,26 @@ var g = &grammar{
 		},
 		{
 			name: "FieldType",
-			pos:  position{line: 264, col: 1, offset: 6252},
+			pos:  position{line: 265, col: 1, offset: 6327},
 			expr: &actionExpr{
-				pos: position{line: 264, col: 13, offset: 6266},
+				pos: position{line: 265, col: 13, offset: 6341},
 				run: (*parser).callonFieldType1,
 				expr: &labeledExpr{
-					pos:   position{line: 264, col: 13, offset: 6266},
+					pos:   position{line: 265, col: 13, offset: 6341},
 					label: "typ",
 					expr: &choiceExpr{
-						pos: position{line: 264, col: 18, offset: 6271},
+						pos: position{line: 265, col: 18, offset: 6346},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 264, col: 18, offset: 6271},
+								pos:  position{line: 265, col: 18, offset: 6346},
 								name: "BaseType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 264, col: 29, offset: 6282},
+								pos:  position{line: 265, col: 29, offset: 6357},
 								name: "ContainerType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 264, col: 45, offset: 6298},
+								pos:  position{line: 265, col: 45, offset: 6373},
 								name: "Identifier",
 							},
 						},
@@ -1166,22 +1181,22 @@ var g = &grammar{
 		},
 		{
 			name: "DefinitionType",
-			pos:  position{line: 271, col: 1, offset: 6408},
+			pos:  position{line: 272, col: 1, offset: 6483},
 			expr: &actionExpr{
-				pos: position{line: 271, col: 18, offset: 6427},
+				pos: position{line: 272, col: 18, offset: 6502},
 				run: (*parser).callonDefinitionType1,
 				expr: &labeledExpr{
-					pos:   position{line: 271, col: 18, offset: 6427},
+					pos:   position{line: 272, col: 18, offset: 6502},
 					label: "typ",
 					expr: &choiceExpr{
-						pos: position{line: 271, col: 23, offset: 6432},
+						pos: position{line: 272, col: 23, offset: 6507},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 271, col: 23, offset: 6432},
+								pos:  position{line: 272, col: 23, offset: 6507},
 								name: "BaseType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 271, col: 34, offset: 6443},
+								pos:  position{line: 272, col: 34, offset: 6518},
 								name: "ContainerType",
 							},
 						},
@@ -1191,32 +1206,32 @@ var g = &grammar{
 		},
 		{
 			name: "BaseType",
-			pos:  position{line: 275, col: 1, offset: 6480},
+			pos:  position{line: 276, col: 1, offset: 6555},
 			expr: &actionExpr{
-				pos: position{line: 275, col: 12, offset: 6493},
+				pos: position{line: 276, col: 12, offset: 6568},
 				run: (*parser).callonBaseType1,
 				expr: &seqExpr{
-					pos: position{line: 275, col: 12, offset: 6493},
+					pos: position{line: 276, col: 12, offset: 6568},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 275, col: 12, offset: 6493},
+							pos:   position{line: 276, col: 12, offset: 6568},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 275, col: 17, offset: 6498},
+								pos:  position{line: 276, col: 17, offset: 6573},
 								name: "BaseTypeName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 275, col: 30, offset: 6511},
+							pos:  position{line: 276, col: 30, offset: 6586},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 275, col: 33, offset: 6514},
+							pos:   position{line: 276, col: 33, offset: 6589},
 							label: "annotations",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 275, col: 45, offset: 6526},
+								pos: position{line: 276, col: 45, offset: 6601},
 								expr: &ruleRefExpr{
-									pos:  position{line: 275, col: 45, offset: 6526},
+									pos:  position{line: 276, col: 45, offset: 6601},
 									name: "TypeAnnotations",
 								},
 							},
@@ -1227,50 +1242,50 @@ var g = &grammar{
 		},
 		{
 			name: "BaseTypeName",
-			pos:  position{line: 282, col: 1, offset: 6637},
+			pos:  position{line: 283, col: 1, offset: 6712},
 			expr: &actionExpr{
-				pos: position{line: 282, col: 16, offset: 6654},
+				pos: position{line: 283, col: 16, offset: 6729},
 				run: (*parser).callonBaseTypeName1,
 				expr: &choiceExpr{
-					pos: position{line: 282, col: 17, offset: 6655},
+					pos: position{line: 283, col: 17, offset: 6730},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 282, col: 17, offset: 6655},
+							pos:        position{line: 283, col: 17, offset: 6730},
 							val:        "bool",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 282, col: 26, offset: 6664},
+							pos:        position{line: 283, col: 26, offset: 6739},
 							val:        "byte",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 282, col: 35, offset: 6673},
+							pos:        position{line: 283, col: 35, offset: 6748},
 							val:        "i16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 282, col: 43, offset: 6681},
+							pos:        position{line: 283, col: 43, offset: 6756},
 							val:        "i32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 282, col: 51, offset: 6689},
+							pos:        position{line: 283, col: 51, offset: 6764},
 							val:        "i64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 282, col: 59, offset: 6697},
+							pos:        position{line: 283, col: 59, offset: 6772},
 							val:        "double",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 282, col: 70, offset: 6708},
+							pos:        position{line: 283, col: 70, offset: 6783},
 							val:        "string",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 282, col: 81, offset: 6719},
+							pos:        position{line: 283, col: 81, offset: 6794},
 							val:        "binary",
 							ignoreCase: false,
 						},
@@ -1280,26 +1295,26 @@ var g = &grammar{
 		},
 		{
 			name: "ContainerType",
-			pos:  position{line: 286, col: 1, offset: 6763},
+			pos:  position{line: 287, col: 1, offset: 6838},
 			expr: &actionExpr{
-				pos: position{line: 286, col: 17, offset: 6781},
+				pos: position{line: 287, col: 17, offset: 6856},
 				run: (*parser).callonContainerType1,
 				expr: &labeledExpr{
-					pos:   position{line: 286, col: 17, offset: 6781},
+					pos:   position{line: 287, col: 17, offset: 6856},
 					label: "typ",
 					expr: &choiceExpr{
-						pos: position{line: 286, col: 22, offset: 6786},
+						pos: position{line: 287, col: 22, offset: 6861},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 286, col: 22, offset: 6786},
+								pos:  position{line: 287, col: 22, offset: 6861},
 								name: "MapType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 286, col: 32, offset: 6796},
+								pos:  position{line: 287, col: 32, offset: 6871},
 								name: "SetType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 286, col: 42, offset: 6806},
+								pos:  position{line: 287, col: 42, offset: 6881},
 								name: "ListType",
 							},
 						},
@@ -1309,87 +1324,87 @@ var g = &grammar{
 		},
 		{
 			name: "MapType",
-			pos:  position{line: 290, col: 1, offset: 6838},
+			pos:  position{line: 291, col: 1, offset: 6913},
 			expr: &actionExpr{
-				pos: position{line: 290, col: 11, offset: 6850},
+				pos: position{line: 291, col: 11, offset: 6925},
 				run: (*parser).callonMapType1,
 				expr: &seqExpr{
-					pos: position{line: 290, col: 11, offset: 6850},
+					pos: position{line: 291, col: 11, offset: 6925},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 290, col: 11, offset: 6850},
+							pos: position{line: 291, col: 11, offset: 6925},
 							expr: &ruleRefExpr{
-								pos:  position{line: 290, col: 11, offset: 6850},
+								pos:  position{line: 291, col: 11, offset: 6925},
 								name: "CppType",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 290, col: 20, offset: 6859},
+							pos:        position{line: 291, col: 20, offset: 6934},
 							val:        "map",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 290, col: 26, offset: 6865},
+							pos:  position{line: 291, col: 26, offset: 6940},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 290, col: 29, offset: 6868},
+							pos:        position{line: 291, col: 29, offset: 6943},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 290, col: 33, offset: 6872},
+							pos:  position{line: 291, col: 33, offset: 6947},
 							name: "WS",
 						},
 						&labeledExpr{
-							pos:   position{line: 290, col: 36, offset: 6875},
+							pos:   position{line: 291, col: 36, offset: 6950},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 290, col: 40, offset: 6879},
+								pos:  position{line: 291, col: 40, offset: 6954},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 290, col: 50, offset: 6889},
+							pos:  position{line: 291, col: 50, offset: 6964},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 290, col: 53, offset: 6892},
+							pos:        position{line: 291, col: 53, offset: 6967},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 290, col: 57, offset: 6896},
+							pos:  position{line: 291, col: 57, offset: 6971},
 							name: "WS",
 						},
 						&labeledExpr{
-							pos:   position{line: 290, col: 60, offset: 6899},
+							pos:   position{line: 291, col: 60, offset: 6974},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 290, col: 66, offset: 6905},
+								pos:  position{line: 291, col: 66, offset: 6980},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 290, col: 76, offset: 6915},
+							pos:  position{line: 291, col: 76, offset: 6990},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 290, col: 79, offset: 6918},
+							pos:        position{line: 291, col: 79, offset: 6993},
 							val:        ">",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 290, col: 83, offset: 6922},
+							pos:  position{line: 291, col: 83, offset: 6997},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 290, col: 86, offset: 6925},
+							pos:   position{line: 291, col: 86, offset: 7000},
 							label: "annotations",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 290, col: 98, offset: 6937},
+								pos: position{line: 291, col: 98, offset: 7012},
 								expr: &ruleRefExpr{
-									pos:  position{line: 290, col: 98, offset: 6937},
+									pos:  position{line: 291, col: 98, offset: 7012},
 									name: "TypeAnnotations",
 								},
 							},
@@ -1400,66 +1415,66 @@ var g = &grammar{
 		},
 		{
 			name: "SetType",
-			pos:  position{line: 299, col: 1, offset: 7092},
+			pos:  position{line: 300, col: 1, offset: 7167},
 			expr: &actionExpr{
-				pos: position{line: 299, col: 11, offset: 7104},
+				pos: position{line: 300, col: 11, offset: 7179},
 				run: (*parser).callonSetType1,
 				expr: &seqExpr{
-					pos: position{line: 299, col: 11, offset: 7104},
+					pos: position{line: 300, col: 11, offset: 7179},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 299, col: 11, offset: 7104},
+							pos: position{line: 300, col: 11, offset: 7179},
 							expr: &ruleRefExpr{
-								pos:  position{line: 299, col: 11, offset: 7104},
+								pos:  position{line: 300, col: 11, offset: 7179},
 								name: "CppType",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 299, col: 20, offset: 7113},
+							pos:        position{line: 300, col: 20, offset: 7188},
 							val:        "set",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 299, col: 26, offset: 7119},
+							pos:  position{line: 300, col: 26, offset: 7194},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 299, col: 29, offset: 7122},
+							pos:        position{line: 300, col: 29, offset: 7197},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 299, col: 33, offset: 7126},
+							pos:  position{line: 300, col: 33, offset: 7201},
 							name: "WS",
 						},
 						&labeledExpr{
-							pos:   position{line: 299, col: 36, offset: 7129},
+							pos:   position{line: 300, col: 36, offset: 7204},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 299, col: 40, offset: 7133},
+								pos:  position{line: 300, col: 40, offset: 7208},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 299, col: 50, offset: 7143},
+							pos:  position{line: 300, col: 50, offset: 7218},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 299, col: 53, offset: 7146},
+							pos:        position{line: 300, col: 53, offset: 7221},
 							val:        ">",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 299, col: 57, offset: 7150},
+							pos:  position{line: 300, col: 57, offset: 7225},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 299, col: 60, offset: 7153},
+							pos:   position{line: 300, col: 60, offset: 7228},
 							label: "annotations",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 299, col: 72, offset: 7165},
+								pos: position{line: 300, col: 72, offset: 7240},
 								expr: &ruleRefExpr{
-									pos:  position{line: 299, col: 72, offset: 7165},
+									pos:  position{line: 300, col: 72, offset: 7240},
 									name: "TypeAnnotations",
 								},
 							},
@@ -1470,59 +1485,59 @@ var g = &grammar{
 		},
 		{
 			name: "ListType",
-			pos:  position{line: 307, col: 1, offset: 7294},
+			pos:  position{line: 308, col: 1, offset: 7369},
 			expr: &actionExpr{
-				pos: position{line: 307, col: 12, offset: 7307},
+				pos: position{line: 308, col: 12, offset: 7382},
 				run: (*parser).callonListType1,
 				expr: &seqExpr{
-					pos: position{line: 307, col: 12, offset: 7307},
+					pos: position{line: 308, col: 12, offset: 7382},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 307, col: 12, offset: 7307},
+							pos:        position{line: 308, col: 12, offset: 7382},
 							val:        "list",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 307, col: 19, offset: 7314},
+							pos:  position{line: 308, col: 19, offset: 7389},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 307, col: 22, offset: 7317},
+							pos:        position{line: 308, col: 22, offset: 7392},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 307, col: 26, offset: 7321},
+							pos:  position{line: 308, col: 26, offset: 7396},
 							name: "WS",
 						},
 						&labeledExpr{
-							pos:   position{line: 307, col: 29, offset: 7324},
+							pos:   position{line: 308, col: 29, offset: 7399},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 307, col: 33, offset: 7328},
+								pos:  position{line: 308, col: 33, offset: 7403},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 307, col: 43, offset: 7338},
+							pos:  position{line: 308, col: 43, offset: 7413},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 307, col: 46, offset: 7341},
+							pos:        position{line: 308, col: 46, offset: 7416},
 							val:        ">",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 307, col: 50, offset: 7345},
+							pos:  position{line: 308, col: 50, offset: 7420},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 307, col: 53, offset: 7348},
+							pos:   position{line: 308, col: 53, offset: 7423},
 							label: "annotations",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 307, col: 65, offset: 7360},
+								pos: position{line: 308, col: 65, offset: 7435},
 								expr: &ruleRefExpr{
-									pos:  position{line: 307, col: 65, offset: 7360},
+									pos:  position{line: 308, col: 65, offset: 7435},
 									name: "TypeAnnotations",
 								},
 							},
@@ -1533,23 +1548,23 @@ var g = &grammar{
 		},
 		{
 			name: "CppType",
-			pos:  position{line: 315, col: 1, offset: 7490},
+			pos:  position{line: 316, col: 1, offset: 7565},
 			expr: &actionExpr{
-				pos: position{line: 315, col: 11, offset: 7502},
+				pos: position{line: 316, col: 11, offset: 7577},
 				run: (*parser).callonCppType1,
 				expr: &seqExpr{
-					pos: position{line: 315, col: 11, offset: 7502},
+					pos: position{line: 316, col: 11, offset: 7577},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 315, col: 11, offset: 7502},
+							pos:        position{line: 316, col: 11, offset: 7577},
 							val:        "cpp_type",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 315, col: 22, offset: 7513},
+							pos:   position{line: 316, col: 22, offset: 7588},
 							label: "cppType",
 							expr: &ruleRefExpr{
-								pos:  position{line: 315, col: 30, offset: 7521},
+								pos:  position{line: 316, col: 30, offset: 7596},
 								name: "Literal",
 							},
 						},
@@ -1559,32 +1574,32 @@ var g = &grammar{
 		},
 		{
 			name: "ConstValue",
-			pos:  position{line: 319, col: 1, offset: 7555},
+			pos:  position{line: 320, col: 1, offset: 7630},
 			expr: &choiceExpr{
-				pos: position{line: 319, col: 14, offset: 7570},
+				pos: position{line: 320, col: 14, offset: 7645},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 319, col: 14, offset: 7570},
+						pos:  position{line: 320, col: 14, offset: 7645},
 						name: "Literal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 319, col: 24, offset: 7580},
+						pos:  position{line: 320, col: 24, offset: 7655},
 						name: "DoubleConstant",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 319, col: 41, offset: 7597},
+						pos:  position{line: 320, col: 41, offset: 7672},
 						name: "IntConstant",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 319, col: 55, offset: 7611},
+						pos:  position{line: 320, col: 55, offset: 7686},
 						name: "ConstMap",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 319, col: 66, offset: 7622},
+						pos:  position{line: 320, col: 66, offset: 7697},
 						name: "ConstList",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 319, col: 78, offset: 7634},
+						pos:  position{line: 320, col: 78, offset: 7709},
 						name: "Identifier",
 					},
 				},
@@ -1592,35 +1607,35 @@ var g = &grammar{
 		},
 		{
 			name: "TypeAnnotations",
-			pos:  position{line: 321, col: 1, offset: 7646},
+			pos:  position{line: 322, col: 1, offset: 7721},
 			expr: &actionExpr{
-				pos: position{line: 321, col: 19, offset: 7666},
+				pos: position{line: 322, col: 19, offset: 7741},
 				run: (*parser).callonTypeAnnotations1,
 				expr: &seqExpr{
-					pos: position{line: 321, col: 19, offset: 7666},
+					pos: position{line: 322, col: 19, offset: 7741},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 321, col: 19, offset: 7666},
+							pos:        position{line: 322, col: 19, offset: 7741},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 321, col: 23, offset: 7670},
+							pos:  position{line: 322, col: 23, offset: 7745},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 321, col: 26, offset: 7673},
+							pos:   position{line: 322, col: 26, offset: 7748},
 							label: "annotations",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 321, col: 38, offset: 7685},
+								pos: position{line: 322, col: 38, offset: 7760},
 								expr: &ruleRefExpr{
-									pos:  position{line: 321, col: 38, offset: 7685},
+									pos:  position{line: 322, col: 38, offset: 7760},
 									name: "TypeAnnotation",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 321, col: 54, offset: 7701},
+							pos:        position{line: 322, col: 54, offset: 7776},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -1630,50 +1645,50 @@ var g = &grammar{
 		},
 		{
 			name: "TypeAnnotation",
-			pos:  position{line: 329, col: 1, offset: 7847},
+			pos:  position{line: 330, col: 1, offset: 7922},
 			expr: &actionExpr{
-				pos: position{line: 329, col: 18, offset: 7866},
+				pos: position{line: 330, col: 18, offset: 7941},
 				run: (*parser).callonTypeAnnotation1,
 				expr: &seqExpr{
-					pos: position{line: 329, col: 18, offset: 7866},
+					pos: position{line: 330, col: 18, offset: 7941},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 329, col: 18, offset: 7866},
+							pos:   position{line: 330, col: 18, offset: 7941},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 329, col: 23, offset: 7871},
+								pos:  position{line: 330, col: 23, offset: 7946},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 329, col: 34, offset: 7882},
+							pos:  position{line: 330, col: 34, offset: 7957},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 329, col: 36, offset: 7884},
+							pos:   position{line: 330, col: 36, offset: 7959},
 							label: "value",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 329, col: 42, offset: 7890},
+								pos: position{line: 330, col: 42, offset: 7965},
 								expr: &actionExpr{
-									pos: position{line: 329, col: 43, offset: 7891},
+									pos: position{line: 330, col: 43, offset: 7966},
 									run: (*parser).callonTypeAnnotation8,
 									expr: &seqExpr{
-										pos: position{line: 329, col: 43, offset: 7891},
+										pos: position{line: 330, col: 43, offset: 7966},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 329, col: 43, offset: 7891},
+												pos:        position{line: 330, col: 43, offset: 7966},
 												val:        "=",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 329, col: 47, offset: 7895},
+												pos:  position{line: 330, col: 47, offset: 7970},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 329, col: 50, offset: 7898},
+												pos:   position{line: 330, col: 50, offset: 7973},
 												label: "value",
 												expr: &ruleRefExpr{
-													pos:  position{line: 329, col: 56, offset: 7904},
+													pos:  position{line: 330, col: 56, offset: 7979},
 													name: "Literal",
 												},
 											},
@@ -1683,14 +1698,14 @@ var g = &grammar{
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 329, col: 88, offset: 7936},
+							pos: position{line: 330, col: 88, offset: 8011},
 							expr: &ruleRefExpr{
-								pos:  position{line: 329, col: 88, offset: 7936},
+								pos:  position{line: 330, col: 88, offset: 8011},
 								name: "ListSeparator",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 329, col: 103, offset: 7951},
+							pos:  position{line: 330, col: 103, offset: 8026},
 							name: "__",
 						},
 					},
@@ -1699,17 +1714,17 @@ var g = &grammar{
 		},
 		{
 			name: "IntConstant",
-			pos:  position{line: 340, col: 1, offset: 8114},
+			pos:  position{line: 341, col: 1, offset: 8189},
 			expr: &actionExpr{
-				pos: position{line: 340, col: 15, offset: 8130},
+				pos: position{line: 341, col: 15, offset: 8205},
 				run: (*parser).callonIntConstant1,
 				expr: &seqExpr{
-					pos: position{line: 340, col: 15, offset: 8130},
+					pos: position{line: 341, col: 15, offset: 8205},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 340, col: 15, offset: 8130},
+							pos: position{line: 341, col: 15, offset: 8205},
 							expr: &charClassMatcher{
-								pos:        position{line: 340, col: 15, offset: 8130},
+								pos:        position{line: 341, col: 15, offset: 8205},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -1717,9 +1732,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 340, col: 21, offset: 8136},
+							pos: position{line: 341, col: 21, offset: 8211},
 							expr: &ruleRefExpr{
-								pos:  position{line: 340, col: 21, offset: 8136},
+								pos:  position{line: 341, col: 21, offset: 8211},
 								name: "Digit",
 							},
 						},
@@ -1729,17 +1744,17 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleConstant",
-			pos:  position{line: 344, col: 1, offset: 8197},
+			pos:  position{line: 345, col: 1, offset: 8272},
 			expr: &actionExpr{
-				pos: position{line: 344, col: 18, offset: 8216},
+				pos: position{line: 345, col: 18, offset: 8291},
 				run: (*parser).callonDoubleConstant1,
 				expr: &seqExpr{
-					pos: position{line: 344, col: 18, offset: 8216},
+					pos: position{line: 345, col: 18, offset: 8291},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 344, col: 18, offset: 8216},
+							pos: position{line: 345, col: 18, offset: 8291},
 							expr: &charClassMatcher{
-								pos:        position{line: 344, col: 18, offset: 8216},
+								pos:        position{line: 345, col: 18, offset: 8291},
 								val:        "[+-]",
 								chars:      []rune{'+', '-'},
 								ignoreCase: false,
@@ -1747,38 +1762,38 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 344, col: 24, offset: 8222},
+							pos: position{line: 345, col: 24, offset: 8297},
 							expr: &ruleRefExpr{
-								pos:  position{line: 344, col: 24, offset: 8222},
+								pos:  position{line: 345, col: 24, offset: 8297},
 								name: "Digit",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 344, col: 31, offset: 8229},
+							pos:        position{line: 345, col: 31, offset: 8304},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 344, col: 35, offset: 8233},
+							pos: position{line: 345, col: 35, offset: 8308},
 							expr: &ruleRefExpr{
-								pos:  position{line: 344, col: 35, offset: 8233},
+								pos:  position{line: 345, col: 35, offset: 8308},
 								name: "Digit",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 344, col: 42, offset: 8240},
+							pos: position{line: 345, col: 42, offset: 8315},
 							expr: &seqExpr{
-								pos: position{line: 344, col: 44, offset: 8242},
+								pos: position{line: 345, col: 44, offset: 8317},
 								exprs: []interface{}{
 									&charClassMatcher{
-										pos:        position{line: 344, col: 44, offset: 8242},
+										pos:        position{line: 345, col: 44, offset: 8317},
 										val:        "['Ee']",
 										chars:      []rune{'\'', 'E', 'e', '\''},
 										ignoreCase: false,
 										inverted:   false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 344, col: 51, offset: 8249},
+										pos:  position{line: 345, col: 51, offset: 8324},
 										name: "IntConstant",
 									},
 								},
@@ -1790,47 +1805,47 @@ var g = &grammar{
 		},
 		{
 			name: "ConstList",
-			pos:  position{line: 348, col: 1, offset: 8316},
+			pos:  position{line: 349, col: 1, offset: 8391},
 			expr: &actionExpr{
-				pos: position{line: 348, col: 13, offset: 8330},
+				pos: position{line: 349, col: 13, offset: 8405},
 				run: (*parser).callonConstList1,
 				expr: &seqExpr{
-					pos: position{line: 348, col: 13, offset: 8330},
+					pos: position{line: 349, col: 13, offset: 8405},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 348, col: 13, offset: 8330},
+							pos:        position{line: 349, col: 13, offset: 8405},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 348, col: 17, offset: 8334},
+							pos:  position{line: 349, col: 17, offset: 8409},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 348, col: 20, offset: 8337},
+							pos:   position{line: 349, col: 20, offset: 8412},
 							label: "values",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 348, col: 27, offset: 8344},
+								pos: position{line: 349, col: 27, offset: 8419},
 								expr: &seqExpr{
-									pos: position{line: 348, col: 28, offset: 8345},
+									pos: position{line: 349, col: 28, offset: 8420},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 348, col: 28, offset: 8345},
+											pos:  position{line: 349, col: 28, offset: 8420},
 											name: "ConstValue",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 348, col: 39, offset: 8356},
+											pos:  position{line: 349, col: 39, offset: 8431},
 											name: "__",
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 348, col: 42, offset: 8359},
+											pos: position{line: 349, col: 42, offset: 8434},
 											expr: &ruleRefExpr{
-												pos:  position{line: 348, col: 42, offset: 8359},
+												pos:  position{line: 349, col: 42, offset: 8434},
 												name: "ListSeparator",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 348, col: 57, offset: 8374},
+											pos:  position{line: 349, col: 57, offset: 8449},
 											name: "__",
 										},
 									},
@@ -1838,11 +1853,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 348, col: 62, offset: 8379},
+							pos:  position{line: 349, col: 62, offset: 8454},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 348, col: 65, offset: 8382},
+							pos:        position{line: 349, col: 65, offset: 8457},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -1852,67 +1867,67 @@ var g = &grammar{
 		},
 		{
 			name: "ConstMap",
-			pos:  position{line: 357, col: 1, offset: 8555},
+			pos:  position{line: 358, col: 1, offset: 8630},
 			expr: &actionExpr{
-				pos: position{line: 357, col: 12, offset: 8568},
+				pos: position{line: 358, col: 12, offset: 8643},
 				run: (*parser).callonConstMap1,
 				expr: &seqExpr{
-					pos: position{line: 357, col: 12, offset: 8568},
+					pos: position{line: 358, col: 12, offset: 8643},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 357, col: 12, offset: 8568},
+							pos:        position{line: 358, col: 12, offset: 8643},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 357, col: 16, offset: 8572},
+							pos:  position{line: 358, col: 16, offset: 8647},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 357, col: 19, offset: 8575},
+							pos:   position{line: 358, col: 19, offset: 8650},
 							label: "values",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 357, col: 26, offset: 8582},
+								pos: position{line: 358, col: 26, offset: 8657},
 								expr: &seqExpr{
-									pos: position{line: 357, col: 27, offset: 8583},
+									pos: position{line: 358, col: 27, offset: 8658},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 357, col: 27, offset: 8583},
+											pos:  position{line: 358, col: 27, offset: 8658},
 											name: "ConstValue",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 357, col: 38, offset: 8594},
+											pos:  position{line: 358, col: 38, offset: 8669},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 357, col: 41, offset: 8597},
+											pos:        position{line: 358, col: 41, offset: 8672},
 											val:        ":",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 357, col: 45, offset: 8601},
+											pos:  position{line: 358, col: 45, offset: 8676},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 357, col: 48, offset: 8604},
+											pos:  position{line: 358, col: 48, offset: 8679},
 											name: "ConstValue",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 357, col: 59, offset: 8615},
+											pos:  position{line: 358, col: 59, offset: 8690},
 											name: "__",
 										},
 										&choiceExpr{
-											pos: position{line: 357, col: 63, offset: 8619},
+											pos: position{line: 358, col: 63, offset: 8694},
 											alternatives: []interface{}{
 												&litMatcher{
-													pos:        position{line: 357, col: 63, offset: 8619},
+													pos:        position{line: 358, col: 63, offset: 8694},
 													val:        ",",
 													ignoreCase: false,
 												},
 												&andExpr{
-													pos: position{line: 357, col: 69, offset: 8625},
+													pos: position{line: 358, col: 69, offset: 8700},
 													expr: &litMatcher{
-														pos:        position{line: 357, col: 70, offset: 8626},
+														pos:        position{line: 358, col: 70, offset: 8701},
 														val:        "}",
 														ignoreCase: false,
 													},
@@ -1920,7 +1935,7 @@ var g = &grammar{
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 357, col: 75, offset: 8631},
+											pos:  position{line: 358, col: 75, offset: 8706},
 											name: "__",
 										},
 									},
@@ -1928,7 +1943,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 357, col: 80, offset: 8636},
+							pos:        position{line: 358, col: 80, offset: 8711},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -1938,33 +1953,33 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 373, col: 1, offset: 8882},
+			pos:  position{line: 374, col: 1, offset: 8957},
 			expr: &actionExpr{
-				pos: position{line: 373, col: 11, offset: 8894},
+				pos: position{line: 374, col: 11, offset: 8969},
 				run: (*parser).callonLiteral1,
 				expr: &choiceExpr{
-					pos: position{line: 373, col: 12, offset: 8895},
+					pos: position{line: 374, col: 12, offset: 8970},
 					alternatives: []interface{}{
 						&seqExpr{
-							pos: position{line: 373, col: 13, offset: 8896},
+							pos: position{line: 374, col: 13, offset: 8971},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 373, col: 13, offset: 8896},
+									pos:        position{line: 374, col: 13, offset: 8971},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 373, col: 17, offset: 8900},
+									pos: position{line: 374, col: 17, offset: 8975},
 									expr: &choiceExpr{
-										pos: position{line: 373, col: 18, offset: 8901},
+										pos: position{line: 374, col: 18, offset: 8976},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 373, col: 18, offset: 8901},
+												pos:        position{line: 374, col: 18, offset: 8976},
 												val:        "\\\"",
 												ignoreCase: false,
 											},
 											&charClassMatcher{
-												pos:        position{line: 373, col: 25, offset: 8908},
+												pos:        position{line: 374, col: 25, offset: 8983},
 												val:        "[^\"]",
 												chars:      []rune{'"'},
 												ignoreCase: false,
@@ -1974,32 +1989,32 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 373, col: 32, offset: 8915},
+									pos:        position{line: 374, col: 32, offset: 8990},
 									val:        "\"",
 									ignoreCase: false,
 								},
 							},
 						},
 						&seqExpr{
-							pos: position{line: 373, col: 40, offset: 8923},
+							pos: position{line: 374, col: 40, offset: 8998},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 373, col: 40, offset: 8923},
+									pos:        position{line: 374, col: 40, offset: 8998},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 373, col: 45, offset: 8928},
+									pos: position{line: 374, col: 45, offset: 9003},
 									expr: &choiceExpr{
-										pos: position{line: 373, col: 46, offset: 8929},
+										pos: position{line: 374, col: 46, offset: 9004},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 373, col: 46, offset: 8929},
+												pos:        position{line: 374, col: 46, offset: 9004},
 												val:        "\\'",
 												ignoreCase: false,
 											},
 											&charClassMatcher{
-												pos:        position{line: 373, col: 53, offset: 8936},
+												pos:        position{line: 374, col: 53, offset: 9011},
 												val:        "[^']",
 												chars:      []rune{'\''},
 												ignoreCase: false,
@@ -2009,7 +2024,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 373, col: 60, offset: 8943},
+									pos:        position{line: 374, col: 60, offset: 9018},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -2021,24 +2036,24 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 380, col: 1, offset: 9144},
+			pos:  position{line: 381, col: 1, offset: 9219},
 			expr: &actionExpr{
-				pos: position{line: 380, col: 14, offset: 9159},
+				pos: position{line: 381, col: 14, offset: 9234},
 				run: (*parser).callonIdentifier1,
 				expr: &seqExpr{
-					pos: position{line: 380, col: 14, offset: 9159},
+					pos: position{line: 381, col: 14, offset: 9234},
 					exprs: []interface{}{
 						&oneOrMoreExpr{
-							pos: position{line: 380, col: 14, offset: 9159},
+							pos: position{line: 381, col: 14, offset: 9234},
 							expr: &choiceExpr{
-								pos: position{line: 380, col: 15, offset: 9160},
+								pos: position{line: 381, col: 15, offset: 9235},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 380, col: 15, offset: 9160},
+										pos:  position{line: 381, col: 15, offset: 9235},
 										name: "Letter",
 									},
 									&litMatcher{
-										pos:        position{line: 380, col: 24, offset: 9169},
+										pos:        position{line: 381, col: 24, offset: 9244},
 										val:        "_",
 										ignoreCase: false,
 									},
@@ -2046,20 +2061,20 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 380, col: 30, offset: 9175},
+							pos: position{line: 381, col: 30, offset: 9250},
 							expr: &choiceExpr{
-								pos: position{line: 380, col: 31, offset: 9176},
+								pos: position{line: 381, col: 31, offset: 9251},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 380, col: 31, offset: 9176},
+										pos:  position{line: 381, col: 31, offset: 9251},
 										name: "Letter",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 380, col: 40, offset: 9185},
+										pos:  position{line: 381, col: 40, offset: 9260},
 										name: "Digit",
 									},
 									&charClassMatcher{
-										pos:        position{line: 380, col: 48, offset: 9193},
+										pos:        position{line: 381, col: 48, offset: 9268},
 										val:        "[._]",
 										chars:      []rune{'.', '_'},
 										ignoreCase: false,
@@ -2074,9 +2089,9 @@ var g = &grammar{
 		},
 		{
 			name: "ListSeparator",
-			pos:  position{line: 384, col: 1, offset: 9245},
+			pos:  position{line: 385, col: 1, offset: 9320},
 			expr: &charClassMatcher{
-				pos:        position{line: 384, col: 17, offset: 9263},
+				pos:        position{line: 385, col: 17, offset: 9338},
 				val:        "[,;]",
 				chars:      []rune{',', ';'},
 				ignoreCase: false,
@@ -2085,9 +2100,9 @@ var g = &grammar{
 		},
 		{
 			name: "Letter",
-			pos:  position{line: 385, col: 1, offset: 9268},
+			pos:  position{line: 386, col: 1, offset: 9343},
 			expr: &charClassMatcher{
-				pos:        position{line: 385, col: 10, offset: 9279},
+				pos:        position{line: 386, col: 10, offset: 9354},
 				val:        "[A-Za-z]",
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
 				ignoreCase: false,
@@ -2096,9 +2111,9 @@ var g = &grammar{
 		},
 		{
 			name: "Digit",
-			pos:  position{line: 386, col: 1, offset: 9288},
+			pos:  position{line: 387, col: 1, offset: 9363},
 			expr: &charClassMatcher{
-				pos:        position{line: 386, col: 9, offset: 9298},
+				pos:        position{line: 387, col: 9, offset: 9373},
 				val:        "[0-9]",
 				ranges:     []rune{'0', '9'},
 				ignoreCase: false,
@@ -2107,23 +2122,23 @@ var g = &grammar{
 		},
 		{
 			name: "SourceChar",
-			pos:  position{line: 390, col: 1, offset: 9309},
+			pos:  position{line: 391, col: 1, offset: 9384},
 			expr: &anyMatcher{
-				line: 390, col: 14, offset: 9324,
+				line: 391, col: 14, offset: 9399,
 			},
 		},
 		{
 			name: "Comment",
-			pos:  position{line: 391, col: 1, offset: 9326},
+			pos:  position{line: 392, col: 1, offset: 9401},
 			expr: &choiceExpr{
-				pos: position{line: 391, col: 11, offset: 9338},
+				pos: position{line: 392, col: 11, offset: 9413},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 391, col: 11, offset: 9338},
+						pos:  position{line: 392, col: 11, offset: 9413},
 						name: "MultiLineComment",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 391, col: 30, offset: 9357},
+						pos:  position{line: 392, col: 30, offset: 9432},
 						name: "SingleLineComment",
 					},
 				},
@@ -2131,37 +2146,37 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 392, col: 1, offset: 9375},
+			pos:  position{line: 393, col: 1, offset: 9450},
 			expr: &seqExpr{
-				pos: position{line: 392, col: 20, offset: 9396},
+				pos: position{line: 393, col: 20, offset: 9471},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 392, col: 20, offset: 9396},
+						pos:        position{line: 393, col: 20, offset: 9471},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 392, col: 25, offset: 9401},
+						pos: position{line: 393, col: 25, offset: 9476},
 						expr: &seqExpr{
-							pos: position{line: 392, col: 27, offset: 9403},
+							pos: position{line: 393, col: 27, offset: 9478},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 392, col: 27, offset: 9403},
+									pos: position{line: 393, col: 27, offset: 9478},
 									expr: &litMatcher{
-										pos:        position{line: 392, col: 28, offset: 9404},
+										pos:        position{line: 393, col: 28, offset: 9479},
 										val:        "*/",
 										ignoreCase: false,
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 392, col: 33, offset: 9409},
+									pos:  position{line: 393, col: 33, offset: 9484},
 									name: "SourceChar",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 392, col: 47, offset: 9423},
+						pos:        position{line: 393, col: 47, offset: 9498},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -2170,46 +2185,46 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineCommentNoLineTerminator",
-			pos:  position{line: 393, col: 1, offset: 9428},
+			pos:  position{line: 394, col: 1, offset: 9503},
 			expr: &seqExpr{
-				pos: position{line: 393, col: 36, offset: 9465},
+				pos: position{line: 394, col: 36, offset: 9540},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 393, col: 36, offset: 9465},
+						pos:        position{line: 394, col: 36, offset: 9540},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 393, col: 41, offset: 9470},
+						pos: position{line: 394, col: 41, offset: 9545},
 						expr: &seqExpr{
-							pos: position{line: 393, col: 43, offset: 9472},
+							pos: position{line: 394, col: 43, offset: 9547},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 393, col: 43, offset: 9472},
+									pos: position{line: 394, col: 43, offset: 9547},
 									expr: &choiceExpr{
-										pos: position{line: 393, col: 46, offset: 9475},
+										pos: position{line: 394, col: 46, offset: 9550},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 393, col: 46, offset: 9475},
+												pos:        position{line: 394, col: 46, offset: 9550},
 												val:        "*/",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 393, col: 53, offset: 9482},
+												pos:  position{line: 394, col: 53, offset: 9557},
 												name: "EOL",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 393, col: 59, offset: 9488},
+									pos:  position{line: 394, col: 59, offset: 9563},
 									name: "SourceChar",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 393, col: 73, offset: 9502},
+						pos:        position{line: 394, col: 73, offset: 9577},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -2218,32 +2233,32 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 394, col: 1, offset: 9507},
+			pos:  position{line: 395, col: 1, offset: 9582},
 			expr: &choiceExpr{
-				pos: position{line: 394, col: 21, offset: 9529},
+				pos: position{line: 395, col: 21, offset: 9604},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 394, col: 22, offset: 9530},
+						pos: position{line: 395, col: 22, offset: 9605},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 394, col: 22, offset: 9530},
+								pos:        position{line: 395, col: 22, offset: 9605},
 								val:        "//",
 								ignoreCase: false,
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 394, col: 27, offset: 9535},
+								pos: position{line: 395, col: 27, offset: 9610},
 								expr: &seqExpr{
-									pos: position{line: 394, col: 29, offset: 9537},
+									pos: position{line: 395, col: 29, offset: 9612},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 394, col: 29, offset: 9537},
+											pos: position{line: 395, col: 29, offset: 9612},
 											expr: &ruleRefExpr{
-												pos:  position{line: 394, col: 30, offset: 9538},
+												pos:  position{line: 395, col: 30, offset: 9613},
 												name: "EOL",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 394, col: 34, offset: 9542},
+											pos:  position{line: 395, col: 34, offset: 9617},
 											name: "SourceChar",
 										},
 									},
@@ -2252,27 +2267,27 @@ var g = &grammar{
 						},
 					},
 					&seqExpr{
-						pos: position{line: 394, col: 52, offset: 9560},
+						pos: position{line: 395, col: 52, offset: 9635},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 394, col: 52, offset: 9560},
+								pos:        position{line: 395, col: 52, offset: 9635},
 								val:        "#",
 								ignoreCase: false,
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 394, col: 56, offset: 9564},
+								pos: position{line: 395, col: 56, offset: 9639},
 								expr: &seqExpr{
-									pos: position{line: 394, col: 58, offset: 9566},
+									pos: position{line: 395, col: 58, offset: 9641},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 394, col: 58, offset: 9566},
+											pos: position{line: 395, col: 58, offset: 9641},
 											expr: &ruleRefExpr{
-												pos:  position{line: 394, col: 59, offset: 9567},
+												pos:  position{line: 395, col: 59, offset: 9642},
 												name: "EOL",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 394, col: 63, offset: 9571},
+											pos:  position{line: 395, col: 63, offset: 9646},
 											name: "SourceChar",
 										},
 									},
@@ -2285,22 +2300,22 @@ var g = &grammar{
 		},
 		{
 			name: "__",
-			pos:  position{line: 396, col: 1, offset: 9587},
+			pos:  position{line: 397, col: 1, offset: 9662},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 396, col: 6, offset: 9594},
+				pos: position{line: 397, col: 6, offset: 9669},
 				expr: &choiceExpr{
-					pos: position{line: 396, col: 8, offset: 9596},
+					pos: position{line: 397, col: 8, offset: 9671},
 					alternatives: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 396, col: 8, offset: 9596},
+							pos:  position{line: 397, col: 8, offset: 9671},
 							name: "Whitespace",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 396, col: 21, offset: 9609},
+							pos:  position{line: 397, col: 21, offset: 9684},
 							name: "EOL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 396, col: 27, offset: 9615},
+							pos:  position{line: 397, col: 27, offset: 9690},
 							name: "Comment",
 						},
 					},
@@ -2309,18 +2324,18 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 397, col: 1, offset: 9626},
+			pos:  position{line: 398, col: 1, offset: 9701},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 397, col: 5, offset: 9632},
+				pos: position{line: 398, col: 5, offset: 9707},
 				expr: &choiceExpr{
-					pos: position{line: 397, col: 7, offset: 9634},
+					pos: position{line: 398, col: 7, offset: 9709},
 					alternatives: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 397, col: 7, offset: 9634},
+							pos:  position{line: 398, col: 7, offset: 9709},
 							name: "Whitespace",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 397, col: 20, offset: 9647},
+							pos:  position{line: 398, col: 20, offset: 9722},
 							name: "MultiLineCommentNoLineTerminator",
 						},
 					},
@@ -2329,20 +2344,20 @@ var g = &grammar{
 		},
 		{
 			name: "WS",
-			pos:  position{line: 398, col: 1, offset: 9683},
+			pos:  position{line: 399, col: 1, offset: 9758},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 398, col: 6, offset: 9690},
+				pos: position{line: 399, col: 6, offset: 9765},
 				expr: &ruleRefExpr{
-					pos:  position{line: 398, col: 6, offset: 9690},
+					pos:  position{line: 399, col: 6, offset: 9765},
 					name: "Whitespace",
 				},
 			},
 		},
 		{
 			name: "Whitespace",
-			pos:  position{line: 400, col: 1, offset: 9703},
+			pos:  position{line: 401, col: 1, offset: 9778},
 			expr: &charClassMatcher{
-				pos:        position{line: 400, col: 14, offset: 9718},
+				pos:        position{line: 401, col: 14, offset: 9793},
 				val:        "[ \\t\\r]",
 				chars:      []rune{' ', '\t', '\r'},
 				ignoreCase: false,
@@ -2351,62 +2366,62 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 401, col: 1, offset: 9726},
+			pos:  position{line: 402, col: 1, offset: 9801},
 			expr: &litMatcher{
-				pos:        position{line: 401, col: 7, offset: 9734},
+				pos:        position{line: 402, col: 7, offset: 9809},
 				val:        "\n",
 				ignoreCase: false,
 			},
 		},
 		{
 			name: "EOS",
-			pos:  position{line: 402, col: 1, offset: 9739},
+			pos:  position{line: 403, col: 1, offset: 9814},
 			expr: &choiceExpr{
-				pos: position{line: 402, col: 7, offset: 9747},
+				pos: position{line: 403, col: 7, offset: 9822},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 402, col: 7, offset: 9747},
+						pos: position{line: 403, col: 7, offset: 9822},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 402, col: 7, offset: 9747},
+								pos:  position{line: 403, col: 7, offset: 9822},
 								name: "__",
 							},
 							&litMatcher{
-								pos:        position{line: 402, col: 10, offset: 9750},
+								pos:        position{line: 403, col: 10, offset: 9825},
 								val:        ";",
 								ignoreCase: false,
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 402, col: 16, offset: 9756},
+						pos: position{line: 403, col: 16, offset: 9831},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 402, col: 16, offset: 9756},
+								pos:  position{line: 403, col: 16, offset: 9831},
 								name: "_",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 402, col: 18, offset: 9758},
+								pos: position{line: 403, col: 18, offset: 9833},
 								expr: &ruleRefExpr{
-									pos:  position{line: 402, col: 18, offset: 9758},
+									pos:  position{line: 403, col: 18, offset: 9833},
 									name: "SingleLineComment",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 402, col: 37, offset: 9777},
+								pos:  position{line: 403, col: 37, offset: 9852},
 								name: "EOL",
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 402, col: 43, offset: 9783},
+						pos: position{line: 403, col: 43, offset: 9858},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 402, col: 43, offset: 9783},
+								pos:  position{line: 403, col: 43, offset: 9858},
 								name: "__",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 402, col: 46, offset: 9786},
+								pos:  position{line: 403, col: 46, offset: 9861},
 								name: "EOF",
 							},
 						},
@@ -2416,11 +2431,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 404, col: 1, offset: 9791},
+			pos:  position{line: 405, col: 1, offset: 9866},
 			expr: &notExpr{
-				pos: position{line: 404, col: 7, offset: 9799},
+				pos: position{line: 405, col: 7, offset: 9874},
 				expr: &anyMatcher{
-					line: 404, col: 8, offset: 9800,
+					line: 405, col: 8, offset: 9875,
 				},
 			},
 		},
@@ -2617,9 +2632,10 @@ func (p *parser) callonUnion1() (interface{}, error) {
 	return p.cur.onUnion1(stack["st"])
 }
 
-func (c *current) onStructLike1(name, fields interface{}) (interface{}, error) {
+func (c *current) onStructLike1(name, fields, annotations interface{}) (interface{}, error) {
 	st := &Struct{
-		Name: string(name.(Identifier)),
+		Name:        string(name.(Identifier)),
+		Annotations: toAnnotations(annotations),
 	}
 	if fields != nil {
 		st.Fields = fields.([]*Field)
@@ -2630,7 +2646,7 @@ func (c *current) onStructLike1(name, fields interface{}) (interface{}, error) {
 func (p *parser) callonStructLike1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onStructLike1(stack["name"], stack["fields"])
+	return p.cur.onStructLike1(stack["name"], stack["fields"], stack["annotations"])
 }
 
 func (c *current) onFieldList1(fields interface{}) (interface{}, error) {

--- a/parser/grammar.peg.go
+++ b/parser/grammar.peg.go
@@ -387,21 +387,21 @@ var g = &grammar{
 						},
 						&ruleRefExpr{
 							pos:  position{line: 125, col: 70, offset: 2761},
-							name: "__",
+							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 125, col: 73, offset: 2764},
+							pos:   position{line: 125, col: 72, offset: 2763},
 							label: "annotations",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 125, col: 85, offset: 2776},
+								pos: position{line: 125, col: 84, offset: 2775},
 								expr: &ruleRefExpr{
-									pos:  position{line: 125, col: 85, offset: 2776},
+									pos:  position{line: 125, col: 84, offset: 2775},
 									name: "TypeAnnotations",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 125, col: 102, offset: 2793},
+							pos:  position{line: 125, col: 101, offset: 2792},
 							name: "EOS",
 						},
 					},
@@ -410,44 +410,44 @@ var g = &grammar{
 		},
 		{
 			name: "EnumValue",
-			pos:  position{line: 149, col: 1, offset: 3352},
+			pos:  position{line: 149, col: 1, offset: 3351},
 			expr: &actionExpr{
-				pos: position{line: 149, col: 13, offset: 3366},
+				pos: position{line: 149, col: 13, offset: 3365},
 				run: (*parser).callonEnumValue1,
 				expr: &seqExpr{
-					pos: position{line: 149, col: 13, offset: 3366},
+					pos: position{line: 149, col: 13, offset: 3365},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 149, col: 13, offset: 3366},
+							pos:   position{line: 149, col: 13, offset: 3365},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 149, col: 18, offset: 3371},
+								pos:  position{line: 149, col: 18, offset: 3370},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 149, col: 29, offset: 3382},
+							pos:  position{line: 149, col: 29, offset: 3381},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 149, col: 31, offset: 3384},
+							pos:   position{line: 149, col: 31, offset: 3383},
 							label: "value",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 149, col: 37, offset: 3390},
+								pos: position{line: 149, col: 37, offset: 3389},
 								expr: &seqExpr{
-									pos: position{line: 149, col: 38, offset: 3391},
+									pos: position{line: 149, col: 38, offset: 3390},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 149, col: 38, offset: 3391},
+											pos:        position{line: 149, col: 38, offset: 3390},
 											val:        "=",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 149, col: 42, offset: 3395},
+											pos:  position{line: 149, col: 42, offset: 3394},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 149, col: 44, offset: 3397},
+											pos:  position{line: 149, col: 44, offset: 3396},
 											name: "IntConstant",
 										},
 									},
@@ -455,24 +455,24 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 149, col: 58, offset: 3411},
-							name: "__",
+							pos:  position{line: 149, col: 58, offset: 3410},
+							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 149, col: 61, offset: 3414},
+							pos:   position{line: 149, col: 60, offset: 3412},
 							label: "annotations",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 149, col: 73, offset: 3426},
+								pos: position{line: 149, col: 72, offset: 3424},
 								expr: &ruleRefExpr{
-									pos:  position{line: 149, col: 73, offset: 3426},
+									pos:  position{line: 149, col: 72, offset: 3424},
 									name: "TypeAnnotations",
 								},
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 149, col: 90, offset: 3443},
+							pos: position{line: 149, col: 89, offset: 3441},
 							expr: &ruleRefExpr{
-								pos:  position{line: 149, col: 90, offset: 3443},
+								pos:  position{line: 149, col: 89, offset: 3441},
 								name: "ListSeparator",
 							},
 						},
@@ -482,59 +482,59 @@ var g = &grammar{
 		},
 		{
 			name: "TypeDef",
-			pos:  position{line: 161, col: 1, offset: 3665},
+			pos:  position{line: 161, col: 1, offset: 3663},
 			expr: &actionExpr{
-				pos: position{line: 161, col: 11, offset: 3677},
+				pos: position{line: 161, col: 11, offset: 3675},
 				run: (*parser).callonTypeDef1,
 				expr: &seqExpr{
-					pos: position{line: 161, col: 11, offset: 3677},
+					pos: position{line: 161, col: 11, offset: 3675},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 161, col: 11, offset: 3677},
+							pos:        position{line: 161, col: 11, offset: 3675},
 							val:        "typedef",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 161, col: 21, offset: 3687},
+							pos:  position{line: 161, col: 21, offset: 3685},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 161, col: 23, offset: 3689},
+							pos:   position{line: 161, col: 23, offset: 3687},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 161, col: 27, offset: 3693},
+								pos:  position{line: 161, col: 27, offset: 3691},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 161, col: 37, offset: 3703},
+							pos:  position{line: 161, col: 37, offset: 3701},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 161, col: 39, offset: 3705},
+							pos:   position{line: 161, col: 39, offset: 3703},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 161, col: 44, offset: 3710},
+								pos:  position{line: 161, col: 44, offset: 3708},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 161, col: 55, offset: 3721},
+							pos:  position{line: 161, col: 55, offset: 3719},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 161, col: 57, offset: 3723},
+							pos:   position{line: 161, col: 57, offset: 3721},
 							label: "annotations",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 161, col: 69, offset: 3735},
+								pos: position{line: 161, col: 69, offset: 3733},
 								expr: &ruleRefExpr{
-									pos:  position{line: 161, col: 69, offset: 3735},
+									pos:  position{line: 161, col: 69, offset: 3733},
 									name: "TypeAnnotations",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 161, col: 86, offset: 3752},
+							pos:  position{line: 161, col: 86, offset: 3750},
 							name: "EOS",
 						},
 					},
@@ -543,27 +543,27 @@ var g = &grammar{
 		},
 		{
 			name: "Struct",
-			pos:  position{line: 170, col: 1, offset: 3888},
+			pos:  position{line: 170, col: 1, offset: 3886},
 			expr: &actionExpr{
-				pos: position{line: 170, col: 10, offset: 3899},
+				pos: position{line: 170, col: 10, offset: 3897},
 				run: (*parser).callonStruct1,
 				expr: &seqExpr{
-					pos: position{line: 170, col: 10, offset: 3899},
+					pos: position{line: 170, col: 10, offset: 3897},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 170, col: 10, offset: 3899},
+							pos:        position{line: 170, col: 10, offset: 3897},
 							val:        "struct",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 170, col: 19, offset: 3908},
+							pos:  position{line: 170, col: 19, offset: 3906},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 170, col: 21, offset: 3910},
+							pos:   position{line: 170, col: 21, offset: 3908},
 							label: "st",
 							expr: &ruleRefExpr{
-								pos:  position{line: 170, col: 24, offset: 3913},
+								pos:  position{line: 170, col: 24, offset: 3911},
 								name: "StructLike",
 							},
 						},
@@ -573,27 +573,27 @@ var g = &grammar{
 		},
 		{
 			name: "Exception",
-			pos:  position{line: 171, col: 1, offset: 3953},
+			pos:  position{line: 171, col: 1, offset: 3951},
 			expr: &actionExpr{
-				pos: position{line: 171, col: 13, offset: 3967},
+				pos: position{line: 171, col: 13, offset: 3965},
 				run: (*parser).callonException1,
 				expr: &seqExpr{
-					pos: position{line: 171, col: 13, offset: 3967},
+					pos: position{line: 171, col: 13, offset: 3965},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 171, col: 13, offset: 3967},
+							pos:        position{line: 171, col: 13, offset: 3965},
 							val:        "exception",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 171, col: 25, offset: 3979},
+							pos:  position{line: 171, col: 25, offset: 3977},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 171, col: 27, offset: 3981},
+							pos:   position{line: 171, col: 27, offset: 3979},
 							label: "st",
 							expr: &ruleRefExpr{
-								pos:  position{line: 171, col: 30, offset: 3984},
+								pos:  position{line: 171, col: 30, offset: 3982},
 								name: "StructLike",
 							},
 						},
@@ -603,27 +603,27 @@ var g = &grammar{
 		},
 		{
 			name: "Union",
-			pos:  position{line: 172, col: 1, offset: 4035},
+			pos:  position{line: 172, col: 1, offset: 4033},
 			expr: &actionExpr{
-				pos: position{line: 172, col: 9, offset: 4045},
+				pos: position{line: 172, col: 9, offset: 4043},
 				run: (*parser).callonUnion1,
 				expr: &seqExpr{
-					pos: position{line: 172, col: 9, offset: 4045},
+					pos: position{line: 172, col: 9, offset: 4043},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 172, col: 9, offset: 4045},
+							pos:        position{line: 172, col: 9, offset: 4043},
 							val:        "union",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 172, col: 17, offset: 4053},
+							pos:  position{line: 172, col: 17, offset: 4051},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 172, col: 19, offset: 4055},
+							pos:   position{line: 172, col: 19, offset: 4053},
 							label: "st",
 							expr: &ruleRefExpr{
-								pos:  position{line: 172, col: 22, offset: 4058},
+								pos:  position{line: 172, col: 22, offset: 4056},
 								name: "StructLike",
 							},
 						},
@@ -633,64 +633,64 @@ var g = &grammar{
 		},
 		{
 			name: "StructLike",
-			pos:  position{line: 173, col: 1, offset: 4105},
+			pos:  position{line: 173, col: 1, offset: 4103},
 			expr: &actionExpr{
-				pos: position{line: 173, col: 14, offset: 4120},
+				pos: position{line: 173, col: 14, offset: 4118},
 				run: (*parser).callonStructLike1,
 				expr: &seqExpr{
-					pos: position{line: 173, col: 14, offset: 4120},
+					pos: position{line: 173, col: 14, offset: 4118},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 173, col: 14, offset: 4120},
+							pos:   position{line: 173, col: 14, offset: 4118},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 173, col: 19, offset: 4125},
+								pos:  position{line: 173, col: 19, offset: 4123},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 173, col: 30, offset: 4136},
+							pos:  position{line: 173, col: 30, offset: 4134},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 173, col: 33, offset: 4139},
+							pos:        position{line: 173, col: 33, offset: 4137},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 173, col: 37, offset: 4143},
+							pos:  position{line: 173, col: 37, offset: 4141},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 173, col: 40, offset: 4146},
+							pos:   position{line: 173, col: 40, offset: 4144},
 							label: "fields",
 							expr: &ruleRefExpr{
-								pos:  position{line: 173, col: 47, offset: 4153},
+								pos:  position{line: 173, col: 47, offset: 4151},
 								name: "FieldList",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 173, col: 57, offset: 4163},
+							pos:        position{line: 173, col: 57, offset: 4161},
 							val:        "}",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 173, col: 61, offset: 4167},
-							name: "__",
+							pos:  position{line: 173, col: 61, offset: 4165},
+							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 173, col: 64, offset: 4170},
+							pos:   position{line: 173, col: 63, offset: 4167},
 							label: "annotations",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 173, col: 76, offset: 4182},
+								pos: position{line: 173, col: 75, offset: 4179},
 								expr: &ruleRefExpr{
-									pos:  position{line: 173, col: 76, offset: 4182},
+									pos:  position{line: 173, col: 75, offset: 4179},
 									name: "TypeAnnotations",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 173, col: 93, offset: 4199},
+							pos:  position{line: 173, col: 92, offset: 4196},
 							name: "EOS",
 						},
 					},
@@ -699,24 +699,24 @@ var g = &grammar{
 		},
 		{
 			name: "FieldList",
-			pos:  position{line: 184, col: 1, offset: 4376},
+			pos:  position{line: 184, col: 1, offset: 4373},
 			expr: &actionExpr{
-				pos: position{line: 184, col: 13, offset: 4390},
+				pos: position{line: 184, col: 13, offset: 4387},
 				run: (*parser).callonFieldList1,
 				expr: &labeledExpr{
-					pos:   position{line: 184, col: 13, offset: 4390},
+					pos:   position{line: 184, col: 13, offset: 4387},
 					label: "fields",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 184, col: 20, offset: 4397},
+						pos: position{line: 184, col: 20, offset: 4394},
 						expr: &seqExpr{
-							pos: position{line: 184, col: 21, offset: 4398},
+							pos: position{line: 184, col: 21, offset: 4395},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 184, col: 21, offset: 4398},
+									pos:  position{line: 184, col: 21, offset: 4395},
 									name: "Field",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 184, col: 27, offset: 4404},
+									pos:  position{line: 184, col: 27, offset: 4401},
 									name: "__",
 								},
 							},
@@ -727,92 +727,92 @@ var g = &grammar{
 		},
 		{
 			name: "Field",
-			pos:  position{line: 193, col: 1, offset: 4564},
+			pos:  position{line: 193, col: 1, offset: 4561},
 			expr: &actionExpr{
-				pos: position{line: 193, col: 9, offset: 4574},
+				pos: position{line: 193, col: 9, offset: 4571},
 				run: (*parser).callonField1,
 				expr: &seqExpr{
-					pos: position{line: 193, col: 9, offset: 4574},
+					pos: position{line: 193, col: 9, offset: 4571},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 193, col: 9, offset: 4574},
+							pos:   position{line: 193, col: 9, offset: 4571},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 193, col: 12, offset: 4577},
+								pos:  position{line: 193, col: 12, offset: 4574},
 								name: "IntConstant",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 193, col: 24, offset: 4589},
+							pos:  position{line: 193, col: 24, offset: 4586},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 193, col: 26, offset: 4591},
+							pos:        position{line: 193, col: 26, offset: 4588},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 193, col: 30, offset: 4595},
+							pos:  position{line: 193, col: 30, offset: 4592},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 193, col: 32, offset: 4597},
+							pos:   position{line: 193, col: 32, offset: 4594},
 							label: "req",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 193, col: 36, offset: 4601},
+								pos: position{line: 193, col: 36, offset: 4598},
 								expr: &ruleRefExpr{
-									pos:  position{line: 193, col: 36, offset: 4601},
+									pos:  position{line: 193, col: 36, offset: 4598},
 									name: "FieldReq",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 193, col: 46, offset: 4611},
+							pos:  position{line: 193, col: 46, offset: 4608},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 193, col: 48, offset: 4613},
+							pos:   position{line: 193, col: 48, offset: 4610},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 193, col: 52, offset: 4617},
+								pos:  position{line: 193, col: 52, offset: 4614},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 193, col: 62, offset: 4627},
+							pos:  position{line: 193, col: 62, offset: 4624},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 193, col: 64, offset: 4629},
+							pos:   position{line: 193, col: 64, offset: 4626},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 193, col: 69, offset: 4634},
+								pos:  position{line: 193, col: 69, offset: 4631},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 193, col: 80, offset: 4645},
+							pos:  position{line: 193, col: 80, offset: 4642},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 193, col: 83, offset: 4648},
+							pos:   position{line: 193, col: 83, offset: 4645},
 							label: "def",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 193, col: 87, offset: 4652},
+								pos: position{line: 193, col: 87, offset: 4649},
 								expr: &seqExpr{
-									pos: position{line: 193, col: 88, offset: 4653},
+									pos: position{line: 193, col: 88, offset: 4650},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 193, col: 88, offset: 4653},
+											pos:        position{line: 193, col: 88, offset: 4650},
 											val:        "=",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 193, col: 92, offset: 4657},
+											pos:  position{line: 193, col: 92, offset: 4654},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 193, col: 94, offset: 4659},
+											pos:  position{line: 193, col: 94, offset: 4656},
 											name: "ConstValue",
 										},
 									},
@@ -820,24 +820,24 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 193, col: 107, offset: 4672},
-							name: "__",
+							pos:  position{line: 193, col: 107, offset: 4669},
+							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 193, col: 110, offset: 4675},
+							pos:   position{line: 193, col: 109, offset: 4671},
 							label: "annotations",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 193, col: 122, offset: 4687},
+								pos: position{line: 193, col: 121, offset: 4683},
 								expr: &ruleRefExpr{
-									pos:  position{line: 193, col: 122, offset: 4687},
+									pos:  position{line: 193, col: 121, offset: 4683},
 									name: "TypeAnnotations",
 								},
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 193, col: 139, offset: 4704},
+							pos: position{line: 193, col: 138, offset: 4700},
 							expr: &ruleRefExpr{
-								pos:  position{line: 193, col: 139, offset: 4704},
+								pos:  position{line: 193, col: 138, offset: 4700},
 								name: "ListSeparator",
 							},
 						},
@@ -847,20 +847,20 @@ var g = &grammar{
 		},
 		{
 			name: "FieldReq",
-			pos:  position{line: 209, col: 1, offset: 5007},
+			pos:  position{line: 209, col: 1, offset: 5003},
 			expr: &actionExpr{
-				pos: position{line: 209, col: 12, offset: 5020},
+				pos: position{line: 209, col: 12, offset: 5016},
 				run: (*parser).callonFieldReq1,
 				expr: &choiceExpr{
-					pos: position{line: 209, col: 13, offset: 5021},
+					pos: position{line: 209, col: 13, offset: 5017},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 209, col: 13, offset: 5021},
+							pos:        position{line: 209, col: 13, offset: 5017},
 							val:        "required",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 209, col: 26, offset: 5034},
+							pos:        position{line: 209, col: 26, offset: 5030},
 							val:        "optional",
 							ignoreCase: false,
 						},
@@ -870,57 +870,57 @@ var g = &grammar{
 		},
 		{
 			name: "Service",
-			pos:  position{line: 213, col: 1, offset: 5105},
+			pos:  position{line: 213, col: 1, offset: 5101},
 			expr: &actionExpr{
-				pos: position{line: 213, col: 11, offset: 5117},
+				pos: position{line: 213, col: 11, offset: 5113},
 				run: (*parser).callonService1,
 				expr: &seqExpr{
-					pos: position{line: 213, col: 11, offset: 5117},
+					pos: position{line: 213, col: 11, offset: 5113},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 213, col: 11, offset: 5117},
+							pos:        position{line: 213, col: 11, offset: 5113},
 							val:        "service",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 213, col: 21, offset: 5127},
+							pos:  position{line: 213, col: 21, offset: 5123},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 213, col: 23, offset: 5129},
+							pos:   position{line: 213, col: 23, offset: 5125},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 213, col: 28, offset: 5134},
+								pos:  position{line: 213, col: 28, offset: 5130},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 213, col: 39, offset: 5145},
+							pos:  position{line: 213, col: 39, offset: 5141},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 213, col: 41, offset: 5147},
+							pos:   position{line: 213, col: 41, offset: 5143},
 							label: "extends",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 213, col: 49, offset: 5155},
+								pos: position{line: 213, col: 49, offset: 5151},
 								expr: &seqExpr{
-									pos: position{line: 213, col: 50, offset: 5156},
+									pos: position{line: 213, col: 50, offset: 5152},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 213, col: 50, offset: 5156},
+											pos:        position{line: 213, col: 50, offset: 5152},
 											val:        "extends",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 213, col: 60, offset: 5166},
+											pos:  position{line: 213, col: 60, offset: 5162},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 213, col: 63, offset: 5169},
+											pos:  position{line: 213, col: 63, offset: 5165},
 											name: "Identifier",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 213, col: 74, offset: 5180},
+											pos:  position{line: 213, col: 74, offset: 5176},
 											name: "__",
 										},
 									},
@@ -928,32 +928,32 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 213, col: 79, offset: 5185},
+							pos:  position{line: 213, col: 79, offset: 5181},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 213, col: 82, offset: 5188},
+							pos:        position{line: 213, col: 82, offset: 5184},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 213, col: 86, offset: 5192},
+							pos:  position{line: 213, col: 86, offset: 5188},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 213, col: 89, offset: 5195},
+							pos:   position{line: 213, col: 89, offset: 5191},
 							label: "methods",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 213, col: 97, offset: 5203},
+								pos: position{line: 213, col: 97, offset: 5199},
 								expr: &seqExpr{
-									pos: position{line: 213, col: 98, offset: 5204},
+									pos: position{line: 213, col: 98, offset: 5200},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 213, col: 98, offset: 5204},
+											pos:  position{line: 213, col: 98, offset: 5200},
 											name: "Function",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 213, col: 107, offset: 5213},
+											pos:  position{line: 213, col: 107, offset: 5209},
 											name: "__",
 										},
 									},
@@ -961,36 +961,36 @@ var g = &grammar{
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 213, col: 113, offset: 5219},
+							pos: position{line: 213, col: 113, offset: 5215},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 213, col: 113, offset: 5219},
+									pos:        position{line: 213, col: 113, offset: 5215},
 									val:        "}",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 213, col: 119, offset: 5225},
+									pos:  position{line: 213, col: 119, offset: 5221},
 									name: "EndOfServiceError",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 213, col: 138, offset: 5244},
-							name: "__",
+							pos:  position{line: 213, col: 138, offset: 5240},
+							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 213, col: 141, offset: 5247},
+							pos:   position{line: 213, col: 140, offset: 5242},
 							label: "annotations",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 213, col: 153, offset: 5259},
+								pos: position{line: 213, col: 152, offset: 5254},
 								expr: &ruleRefExpr{
-									pos:  position{line: 213, col: 153, offset: 5259},
+									pos:  position{line: 213, col: 152, offset: 5254},
 									name: "TypeAnnotations",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 213, col: 171, offset: 5277},
+							pos:  position{line: 213, col: 170, offset: 5272},
 							name: "EOS",
 						},
 					},
@@ -999,39 +999,39 @@ var g = &grammar{
 		},
 		{
 			name: "EndOfServiceError",
-			pos:  position{line: 229, col: 1, offset: 5661},
+			pos:  position{line: 229, col: 1, offset: 5656},
 			expr: &actionExpr{
-				pos: position{line: 229, col: 21, offset: 5683},
+				pos: position{line: 229, col: 21, offset: 5678},
 				run: (*parser).callonEndOfServiceError1,
 				expr: &anyMatcher{
-					line: 229, col: 21, offset: 5683,
+					line: 229, col: 21, offset: 5678,
 				},
 			},
 		},
 		{
 			name: "Function",
-			pos:  position{line: 233, col: 1, offset: 5749},
+			pos:  position{line: 233, col: 1, offset: 5744},
 			expr: &actionExpr{
-				pos: position{line: 233, col: 12, offset: 5762},
+				pos: position{line: 233, col: 12, offset: 5757},
 				run: (*parser).callonFunction1,
 				expr: &seqExpr{
-					pos: position{line: 233, col: 12, offset: 5762},
+					pos: position{line: 233, col: 12, offset: 5757},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 233, col: 12, offset: 5762},
+							pos:   position{line: 233, col: 12, offset: 5757},
 							label: "oneway",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 233, col: 19, offset: 5769},
+								pos: position{line: 233, col: 19, offset: 5764},
 								expr: &seqExpr{
-									pos: position{line: 233, col: 20, offset: 5770},
+									pos: position{line: 233, col: 20, offset: 5765},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 233, col: 20, offset: 5770},
+											pos:        position{line: 233, col: 20, offset: 5765},
 											val:        "oneway",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 233, col: 29, offset: 5779},
+											pos:  position{line: 233, col: 29, offset: 5774},
 											name: "__",
 										},
 									},
@@ -1039,85 +1039,85 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 233, col: 34, offset: 5784},
+							pos:   position{line: 233, col: 34, offset: 5779},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 233, col: 38, offset: 5788},
+								pos:  position{line: 233, col: 38, offset: 5783},
 								name: "FunctionType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 233, col: 51, offset: 5801},
+							pos:  position{line: 233, col: 51, offset: 5796},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 233, col: 54, offset: 5804},
+							pos:   position{line: 233, col: 54, offset: 5799},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 233, col: 59, offset: 5809},
+								pos:  position{line: 233, col: 59, offset: 5804},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 233, col: 70, offset: 5820},
+							pos:  position{line: 233, col: 70, offset: 5815},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 233, col: 72, offset: 5822},
+							pos:        position{line: 233, col: 72, offset: 5817},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 233, col: 76, offset: 5826},
+							pos:  position{line: 233, col: 76, offset: 5821},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 233, col: 79, offset: 5829},
+							pos:   position{line: 233, col: 79, offset: 5824},
 							label: "arguments",
 							expr: &ruleRefExpr{
-								pos:  position{line: 233, col: 89, offset: 5839},
+								pos:  position{line: 233, col: 89, offset: 5834},
 								name: "FieldList",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 233, col: 99, offset: 5849},
+							pos:        position{line: 233, col: 99, offset: 5844},
 							val:        ")",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 233, col: 103, offset: 5853},
+							pos:  position{line: 233, col: 103, offset: 5848},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 233, col: 106, offset: 5856},
+							pos:   position{line: 233, col: 106, offset: 5851},
 							label: "exceptions",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 233, col: 117, offset: 5867},
+								pos: position{line: 233, col: 117, offset: 5862},
 								expr: &ruleRefExpr{
-									pos:  position{line: 233, col: 117, offset: 5867},
+									pos:  position{line: 233, col: 117, offset: 5862},
 									name: "Throws",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 233, col: 125, offset: 5875},
-							name: "__",
+							pos:  position{line: 233, col: 125, offset: 5870},
+							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 233, col: 128, offset: 5878},
+							pos:   position{line: 233, col: 127, offset: 5872},
 							label: "annotations",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 233, col: 140, offset: 5890},
+								pos: position{line: 233, col: 139, offset: 5884},
 								expr: &ruleRefExpr{
-									pos:  position{line: 233, col: 140, offset: 5890},
+									pos:  position{line: 233, col: 139, offset: 5884},
 									name: "TypeAnnotations",
 								},
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 233, col: 157, offset: 5907},
+							pos: position{line: 233, col: 156, offset: 5901},
 							expr: &ruleRefExpr{
-								pos:  position{line: 233, col: 157, offset: 5907},
+								pos:  position{line: 233, col: 156, offset: 5901},
 								name: "ListSeparator",
 							},
 						},
@@ -1127,23 +1127,23 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionType",
-			pos:  position{line: 257, col: 1, offset: 6331},
+			pos:  position{line: 257, col: 1, offset: 6325},
 			expr: &actionExpr{
-				pos: position{line: 257, col: 16, offset: 6348},
+				pos: position{line: 257, col: 16, offset: 6342},
 				run: (*parser).callonFunctionType1,
 				expr: &labeledExpr{
-					pos:   position{line: 257, col: 16, offset: 6348},
+					pos:   position{line: 257, col: 16, offset: 6342},
 					label: "typ",
 					expr: &choiceExpr{
-						pos: position{line: 257, col: 21, offset: 6353},
+						pos: position{line: 257, col: 21, offset: 6347},
 						alternatives: []interface{}{
 							&litMatcher{
-								pos:        position{line: 257, col: 21, offset: 6353},
+								pos:        position{line: 257, col: 21, offset: 6347},
 								val:        "void",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 257, col: 30, offset: 6362},
+								pos:  position{line: 257, col: 30, offset: 6356},
 								name: "FieldType",
 							},
 						},
@@ -1153,41 +1153,41 @@ var g = &grammar{
 		},
 		{
 			name: "Throws",
-			pos:  position{line: 264, col: 1, offset: 6469},
+			pos:  position{line: 264, col: 1, offset: 6463},
 			expr: &actionExpr{
-				pos: position{line: 264, col: 10, offset: 6480},
+				pos: position{line: 264, col: 10, offset: 6474},
 				run: (*parser).callonThrows1,
 				expr: &seqExpr{
-					pos: position{line: 264, col: 10, offset: 6480},
+					pos: position{line: 264, col: 10, offset: 6474},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 264, col: 10, offset: 6480},
+							pos:        position{line: 264, col: 10, offset: 6474},
 							val:        "throws",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 264, col: 19, offset: 6489},
+							pos:  position{line: 264, col: 19, offset: 6483},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 264, col: 22, offset: 6492},
+							pos:        position{line: 264, col: 22, offset: 6486},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 264, col: 26, offset: 6496},
+							pos:  position{line: 264, col: 26, offset: 6490},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 264, col: 29, offset: 6499},
+							pos:   position{line: 264, col: 29, offset: 6493},
 							label: "exceptions",
 							expr: &ruleRefExpr{
-								pos:  position{line: 264, col: 40, offset: 6510},
+								pos:  position{line: 264, col: 40, offset: 6504},
 								name: "FieldList",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 264, col: 50, offset: 6520},
+							pos:        position{line: 264, col: 50, offset: 6514},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -1197,26 +1197,26 @@ var g = &grammar{
 		},
 		{
 			name: "FieldType",
-			pos:  position{line: 268, col: 1, offset: 6553},
+			pos:  position{line: 268, col: 1, offset: 6547},
 			expr: &actionExpr{
-				pos: position{line: 268, col: 13, offset: 6567},
+				pos: position{line: 268, col: 13, offset: 6561},
 				run: (*parser).callonFieldType1,
 				expr: &labeledExpr{
-					pos:   position{line: 268, col: 13, offset: 6567},
+					pos:   position{line: 268, col: 13, offset: 6561},
 					label: "typ",
 					expr: &choiceExpr{
-						pos: position{line: 268, col: 18, offset: 6572},
+						pos: position{line: 268, col: 18, offset: 6566},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 268, col: 18, offset: 6572},
+								pos:  position{line: 268, col: 18, offset: 6566},
 								name: "BaseType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 268, col: 29, offset: 6583},
+								pos:  position{line: 268, col: 29, offset: 6577},
 								name: "ContainerType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 268, col: 45, offset: 6599},
+								pos:  position{line: 268, col: 45, offset: 6593},
 								name: "Identifier",
 							},
 						},
@@ -1226,22 +1226,22 @@ var g = &grammar{
 		},
 		{
 			name: "DefinitionType",
-			pos:  position{line: 275, col: 1, offset: 6709},
+			pos:  position{line: 275, col: 1, offset: 6703},
 			expr: &actionExpr{
-				pos: position{line: 275, col: 18, offset: 6728},
+				pos: position{line: 275, col: 18, offset: 6722},
 				run: (*parser).callonDefinitionType1,
 				expr: &labeledExpr{
-					pos:   position{line: 275, col: 18, offset: 6728},
+					pos:   position{line: 275, col: 18, offset: 6722},
 					label: "typ",
 					expr: &choiceExpr{
-						pos: position{line: 275, col: 23, offset: 6733},
+						pos: position{line: 275, col: 23, offset: 6727},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 275, col: 23, offset: 6733},
+								pos:  position{line: 275, col: 23, offset: 6727},
 								name: "BaseType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 275, col: 34, offset: 6744},
+								pos:  position{line: 275, col: 34, offset: 6738},
 								name: "ContainerType",
 							},
 						},
@@ -1251,32 +1251,32 @@ var g = &grammar{
 		},
 		{
 			name: "BaseType",
-			pos:  position{line: 279, col: 1, offset: 6781},
+			pos:  position{line: 279, col: 1, offset: 6775},
 			expr: &actionExpr{
-				pos: position{line: 279, col: 12, offset: 6794},
+				pos: position{line: 279, col: 12, offset: 6788},
 				run: (*parser).callonBaseType1,
 				expr: &seqExpr{
-					pos: position{line: 279, col: 12, offset: 6794},
+					pos: position{line: 279, col: 12, offset: 6788},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 279, col: 12, offset: 6794},
+							pos:   position{line: 279, col: 12, offset: 6788},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 279, col: 17, offset: 6799},
+								pos:  position{line: 279, col: 17, offset: 6793},
 								name: "BaseTypeName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 279, col: 30, offset: 6812},
-							name: "__",
+							pos:  position{line: 279, col: 30, offset: 6806},
+							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 279, col: 33, offset: 6815},
+							pos:   position{line: 279, col: 32, offset: 6808},
 							label: "annotations",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 279, col: 45, offset: 6827},
+								pos: position{line: 279, col: 44, offset: 6820},
 								expr: &ruleRefExpr{
-									pos:  position{line: 279, col: 45, offset: 6827},
+									pos:  position{line: 279, col: 44, offset: 6820},
 									name: "TypeAnnotations",
 								},
 							},
@@ -1287,50 +1287,50 @@ var g = &grammar{
 		},
 		{
 			name: "BaseTypeName",
-			pos:  position{line: 286, col: 1, offset: 6938},
+			pos:  position{line: 286, col: 1, offset: 6931},
 			expr: &actionExpr{
-				pos: position{line: 286, col: 16, offset: 6955},
+				pos: position{line: 286, col: 16, offset: 6948},
 				run: (*parser).callonBaseTypeName1,
 				expr: &choiceExpr{
-					pos: position{line: 286, col: 17, offset: 6956},
+					pos: position{line: 286, col: 17, offset: 6949},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 286, col: 17, offset: 6956},
+							pos:        position{line: 286, col: 17, offset: 6949},
 							val:        "bool",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 286, col: 26, offset: 6965},
+							pos:        position{line: 286, col: 26, offset: 6958},
 							val:        "byte",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 286, col: 35, offset: 6974},
+							pos:        position{line: 286, col: 35, offset: 6967},
 							val:        "i16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 286, col: 43, offset: 6982},
+							pos:        position{line: 286, col: 43, offset: 6975},
 							val:        "i32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 286, col: 51, offset: 6990},
+							pos:        position{line: 286, col: 51, offset: 6983},
 							val:        "i64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 286, col: 59, offset: 6998},
+							pos:        position{line: 286, col: 59, offset: 6991},
 							val:        "double",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 286, col: 70, offset: 7009},
+							pos:        position{line: 286, col: 70, offset: 7002},
 							val:        "string",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 286, col: 81, offset: 7020},
+							pos:        position{line: 286, col: 81, offset: 7013},
 							val:        "binary",
 							ignoreCase: false,
 						},
@@ -1340,26 +1340,26 @@ var g = &grammar{
 		},
 		{
 			name: "ContainerType",
-			pos:  position{line: 290, col: 1, offset: 7064},
+			pos:  position{line: 290, col: 1, offset: 7057},
 			expr: &actionExpr{
-				pos: position{line: 290, col: 17, offset: 7082},
+				pos: position{line: 290, col: 17, offset: 7075},
 				run: (*parser).callonContainerType1,
 				expr: &labeledExpr{
-					pos:   position{line: 290, col: 17, offset: 7082},
+					pos:   position{line: 290, col: 17, offset: 7075},
 					label: "typ",
 					expr: &choiceExpr{
-						pos: position{line: 290, col: 22, offset: 7087},
+						pos: position{line: 290, col: 22, offset: 7080},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 290, col: 22, offset: 7087},
+								pos:  position{line: 290, col: 22, offset: 7080},
 								name: "MapType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 290, col: 32, offset: 7097},
+								pos:  position{line: 290, col: 32, offset: 7090},
 								name: "SetType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 290, col: 42, offset: 7107},
+								pos:  position{line: 290, col: 42, offset: 7100},
 								name: "ListType",
 							},
 						},
@@ -1369,87 +1369,87 @@ var g = &grammar{
 		},
 		{
 			name: "MapType",
-			pos:  position{line: 294, col: 1, offset: 7139},
+			pos:  position{line: 294, col: 1, offset: 7132},
 			expr: &actionExpr{
-				pos: position{line: 294, col: 11, offset: 7151},
+				pos: position{line: 294, col: 11, offset: 7144},
 				run: (*parser).callonMapType1,
 				expr: &seqExpr{
-					pos: position{line: 294, col: 11, offset: 7151},
+					pos: position{line: 294, col: 11, offset: 7144},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 294, col: 11, offset: 7151},
+							pos: position{line: 294, col: 11, offset: 7144},
 							expr: &ruleRefExpr{
-								pos:  position{line: 294, col: 11, offset: 7151},
+								pos:  position{line: 294, col: 11, offset: 7144},
 								name: "CppType",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 294, col: 20, offset: 7160},
+							pos:        position{line: 294, col: 20, offset: 7153},
 							val:        "map",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 294, col: 26, offset: 7166},
+							pos:  position{line: 294, col: 26, offset: 7159},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 294, col: 29, offset: 7169},
+							pos:        position{line: 294, col: 29, offset: 7162},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 294, col: 33, offset: 7173},
+							pos:  position{line: 294, col: 33, offset: 7166},
 							name: "WS",
 						},
 						&labeledExpr{
-							pos:   position{line: 294, col: 36, offset: 7176},
+							pos:   position{line: 294, col: 36, offset: 7169},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 294, col: 40, offset: 7180},
+								pos:  position{line: 294, col: 40, offset: 7173},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 294, col: 50, offset: 7190},
+							pos:  position{line: 294, col: 50, offset: 7183},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 294, col: 53, offset: 7193},
+							pos:        position{line: 294, col: 53, offset: 7186},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 294, col: 57, offset: 7197},
+							pos:  position{line: 294, col: 57, offset: 7190},
 							name: "WS",
 						},
 						&labeledExpr{
-							pos:   position{line: 294, col: 60, offset: 7200},
+							pos:   position{line: 294, col: 60, offset: 7193},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 294, col: 66, offset: 7206},
+								pos:  position{line: 294, col: 66, offset: 7199},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 294, col: 76, offset: 7216},
+							pos:  position{line: 294, col: 76, offset: 7209},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 294, col: 79, offset: 7219},
+							pos:        position{line: 294, col: 79, offset: 7212},
 							val:        ">",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 294, col: 83, offset: 7223},
-							name: "__",
+							pos:  position{line: 294, col: 83, offset: 7216},
+							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 294, col: 86, offset: 7226},
+							pos:   position{line: 294, col: 85, offset: 7218},
 							label: "annotations",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 294, col: 98, offset: 7238},
+								pos: position{line: 294, col: 97, offset: 7230},
 								expr: &ruleRefExpr{
-									pos:  position{line: 294, col: 98, offset: 7238},
+									pos:  position{line: 294, col: 97, offset: 7230},
 									name: "TypeAnnotations",
 								},
 							},
@@ -1460,66 +1460,66 @@ var g = &grammar{
 		},
 		{
 			name: "SetType",
-			pos:  position{line: 303, col: 1, offset: 7393},
+			pos:  position{line: 303, col: 1, offset: 7385},
 			expr: &actionExpr{
-				pos: position{line: 303, col: 11, offset: 7405},
+				pos: position{line: 303, col: 11, offset: 7397},
 				run: (*parser).callonSetType1,
 				expr: &seqExpr{
-					pos: position{line: 303, col: 11, offset: 7405},
+					pos: position{line: 303, col: 11, offset: 7397},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 303, col: 11, offset: 7405},
+							pos: position{line: 303, col: 11, offset: 7397},
 							expr: &ruleRefExpr{
-								pos:  position{line: 303, col: 11, offset: 7405},
+								pos:  position{line: 303, col: 11, offset: 7397},
 								name: "CppType",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 303, col: 20, offset: 7414},
+							pos:        position{line: 303, col: 20, offset: 7406},
 							val:        "set",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 303, col: 26, offset: 7420},
+							pos:  position{line: 303, col: 26, offset: 7412},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 303, col: 29, offset: 7423},
+							pos:        position{line: 303, col: 29, offset: 7415},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 303, col: 33, offset: 7427},
+							pos:  position{line: 303, col: 33, offset: 7419},
 							name: "WS",
 						},
 						&labeledExpr{
-							pos:   position{line: 303, col: 36, offset: 7430},
+							pos:   position{line: 303, col: 36, offset: 7422},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 303, col: 40, offset: 7434},
+								pos:  position{line: 303, col: 40, offset: 7426},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 303, col: 50, offset: 7444},
+							pos:  position{line: 303, col: 50, offset: 7436},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 303, col: 53, offset: 7447},
+							pos:        position{line: 303, col: 53, offset: 7439},
 							val:        ">",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 303, col: 57, offset: 7451},
-							name: "__",
+							pos:  position{line: 303, col: 57, offset: 7443},
+							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 303, col: 60, offset: 7454},
+							pos:   position{line: 303, col: 59, offset: 7445},
 							label: "annotations",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 303, col: 72, offset: 7466},
+								pos: position{line: 303, col: 71, offset: 7457},
 								expr: &ruleRefExpr{
-									pos:  position{line: 303, col: 72, offset: 7466},
+									pos:  position{line: 303, col: 71, offset: 7457},
 									name: "TypeAnnotations",
 								},
 							},
@@ -1530,59 +1530,59 @@ var g = &grammar{
 		},
 		{
 			name: "ListType",
-			pos:  position{line: 311, col: 1, offset: 7595},
+			pos:  position{line: 311, col: 1, offset: 7586},
 			expr: &actionExpr{
-				pos: position{line: 311, col: 12, offset: 7608},
+				pos: position{line: 311, col: 12, offset: 7599},
 				run: (*parser).callonListType1,
 				expr: &seqExpr{
-					pos: position{line: 311, col: 12, offset: 7608},
+					pos: position{line: 311, col: 12, offset: 7599},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 311, col: 12, offset: 7608},
+							pos:        position{line: 311, col: 12, offset: 7599},
 							val:        "list",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 311, col: 19, offset: 7615},
+							pos:  position{line: 311, col: 19, offset: 7606},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 311, col: 22, offset: 7618},
+							pos:        position{line: 311, col: 22, offset: 7609},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 311, col: 26, offset: 7622},
+							pos:  position{line: 311, col: 26, offset: 7613},
 							name: "WS",
 						},
 						&labeledExpr{
-							pos:   position{line: 311, col: 29, offset: 7625},
+							pos:   position{line: 311, col: 29, offset: 7616},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 311, col: 33, offset: 7629},
+								pos:  position{line: 311, col: 33, offset: 7620},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 311, col: 43, offset: 7639},
+							pos:  position{line: 311, col: 43, offset: 7630},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 311, col: 46, offset: 7642},
+							pos:        position{line: 311, col: 46, offset: 7633},
 							val:        ">",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 311, col: 50, offset: 7646},
-							name: "__",
+							pos:  position{line: 311, col: 50, offset: 7637},
+							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 311, col: 53, offset: 7649},
+							pos:   position{line: 311, col: 52, offset: 7639},
 							label: "annotations",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 311, col: 65, offset: 7661},
+								pos: position{line: 311, col: 64, offset: 7651},
 								expr: &ruleRefExpr{
-									pos:  position{line: 311, col: 65, offset: 7661},
+									pos:  position{line: 311, col: 64, offset: 7651},
 									name: "TypeAnnotations",
 								},
 							},
@@ -1593,23 +1593,23 @@ var g = &grammar{
 		},
 		{
 			name: "CppType",
-			pos:  position{line: 319, col: 1, offset: 7791},
+			pos:  position{line: 319, col: 1, offset: 7781},
 			expr: &actionExpr{
-				pos: position{line: 319, col: 11, offset: 7803},
+				pos: position{line: 319, col: 11, offset: 7793},
 				run: (*parser).callonCppType1,
 				expr: &seqExpr{
-					pos: position{line: 319, col: 11, offset: 7803},
+					pos: position{line: 319, col: 11, offset: 7793},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 319, col: 11, offset: 7803},
+							pos:        position{line: 319, col: 11, offset: 7793},
 							val:        "cpp_type",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 319, col: 22, offset: 7814},
+							pos:   position{line: 319, col: 22, offset: 7804},
 							label: "cppType",
 							expr: &ruleRefExpr{
-								pos:  position{line: 319, col: 30, offset: 7822},
+								pos:  position{line: 319, col: 30, offset: 7812},
 								name: "Literal",
 							},
 						},
@@ -1619,32 +1619,32 @@ var g = &grammar{
 		},
 		{
 			name: "ConstValue",
-			pos:  position{line: 323, col: 1, offset: 7856},
+			pos:  position{line: 323, col: 1, offset: 7846},
 			expr: &choiceExpr{
-				pos: position{line: 323, col: 14, offset: 7871},
+				pos: position{line: 323, col: 14, offset: 7861},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 323, col: 14, offset: 7871},
+						pos:  position{line: 323, col: 14, offset: 7861},
 						name: "Literal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 323, col: 24, offset: 7881},
+						pos:  position{line: 323, col: 24, offset: 7871},
 						name: "DoubleConstant",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 323, col: 41, offset: 7898},
+						pos:  position{line: 323, col: 41, offset: 7888},
 						name: "IntConstant",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 323, col: 55, offset: 7912},
+						pos:  position{line: 323, col: 55, offset: 7902},
 						name: "ConstMap",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 323, col: 66, offset: 7923},
+						pos:  position{line: 323, col: 66, offset: 7913},
 						name: "ConstList",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 323, col: 78, offset: 7935},
+						pos:  position{line: 323, col: 78, offset: 7925},
 						name: "Identifier",
 					},
 				},
@@ -1652,35 +1652,35 @@ var g = &grammar{
 		},
 		{
 			name: "TypeAnnotations",
-			pos:  position{line: 325, col: 1, offset: 7947},
+			pos:  position{line: 325, col: 1, offset: 7937},
 			expr: &actionExpr{
-				pos: position{line: 325, col: 19, offset: 7967},
+				pos: position{line: 325, col: 19, offset: 7957},
 				run: (*parser).callonTypeAnnotations1,
 				expr: &seqExpr{
-					pos: position{line: 325, col: 19, offset: 7967},
+					pos: position{line: 325, col: 19, offset: 7957},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 325, col: 19, offset: 7967},
+							pos:        position{line: 325, col: 19, offset: 7957},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 325, col: 23, offset: 7971},
+							pos:  position{line: 325, col: 23, offset: 7961},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 325, col: 26, offset: 7974},
+							pos:   position{line: 325, col: 26, offset: 7964},
 							label: "annotations",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 325, col: 38, offset: 7986},
+								pos: position{line: 325, col: 38, offset: 7976},
 								expr: &ruleRefExpr{
-									pos:  position{line: 325, col: 38, offset: 7986},
+									pos:  position{line: 325, col: 38, offset: 7976},
 									name: "TypeAnnotation",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 325, col: 54, offset: 8002},
+							pos:        position{line: 325, col: 54, offset: 7992},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -1690,50 +1690,50 @@ var g = &grammar{
 		},
 		{
 			name: "TypeAnnotation",
-			pos:  position{line: 333, col: 1, offset: 8148},
+			pos:  position{line: 333, col: 1, offset: 8138},
 			expr: &actionExpr{
-				pos: position{line: 333, col: 18, offset: 8167},
+				pos: position{line: 333, col: 18, offset: 8157},
 				run: (*parser).callonTypeAnnotation1,
 				expr: &seqExpr{
-					pos: position{line: 333, col: 18, offset: 8167},
+					pos: position{line: 333, col: 18, offset: 8157},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 333, col: 18, offset: 8167},
+							pos:   position{line: 333, col: 18, offset: 8157},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 333, col: 23, offset: 8172},
+								pos:  position{line: 333, col: 23, offset: 8162},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 333, col: 34, offset: 8183},
+							pos:  position{line: 333, col: 34, offset: 8173},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 333, col: 36, offset: 8185},
+							pos:   position{line: 333, col: 36, offset: 8175},
 							label: "value",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 333, col: 42, offset: 8191},
+								pos: position{line: 333, col: 42, offset: 8181},
 								expr: &actionExpr{
-									pos: position{line: 333, col: 43, offset: 8192},
+									pos: position{line: 333, col: 43, offset: 8182},
 									run: (*parser).callonTypeAnnotation8,
 									expr: &seqExpr{
-										pos: position{line: 333, col: 43, offset: 8192},
+										pos: position{line: 333, col: 43, offset: 8182},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 333, col: 43, offset: 8192},
+												pos:        position{line: 333, col: 43, offset: 8182},
 												val:        "=",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 333, col: 47, offset: 8196},
+												pos:  position{line: 333, col: 47, offset: 8186},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 333, col: 50, offset: 8199},
+												pos:   position{line: 333, col: 50, offset: 8189},
 												label: "value",
 												expr: &ruleRefExpr{
-													pos:  position{line: 333, col: 56, offset: 8205},
+													pos:  position{line: 333, col: 56, offset: 8195},
 													name: "Literal",
 												},
 											},
@@ -1743,14 +1743,14 @@ var g = &grammar{
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 333, col: 88, offset: 8237},
+							pos: position{line: 333, col: 88, offset: 8227},
 							expr: &ruleRefExpr{
-								pos:  position{line: 333, col: 88, offset: 8237},
+								pos:  position{line: 333, col: 88, offset: 8227},
 								name: "ListSeparator",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 333, col: 103, offset: 8252},
+							pos:  position{line: 333, col: 103, offset: 8242},
 							name: "__",
 						},
 					},
@@ -1759,17 +1759,17 @@ var g = &grammar{
 		},
 		{
 			name: "IntConstant",
-			pos:  position{line: 344, col: 1, offset: 8415},
+			pos:  position{line: 344, col: 1, offset: 8405},
 			expr: &actionExpr{
-				pos: position{line: 344, col: 15, offset: 8431},
+				pos: position{line: 344, col: 15, offset: 8421},
 				run: (*parser).callonIntConstant1,
 				expr: &seqExpr{
-					pos: position{line: 344, col: 15, offset: 8431},
+					pos: position{line: 344, col: 15, offset: 8421},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 344, col: 15, offset: 8431},
+							pos: position{line: 344, col: 15, offset: 8421},
 							expr: &charClassMatcher{
-								pos:        position{line: 344, col: 15, offset: 8431},
+								pos:        position{line: 344, col: 15, offset: 8421},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -1777,9 +1777,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 344, col: 21, offset: 8437},
+							pos: position{line: 344, col: 21, offset: 8427},
 							expr: &ruleRefExpr{
-								pos:  position{line: 344, col: 21, offset: 8437},
+								pos:  position{line: 344, col: 21, offset: 8427},
 								name: "Digit",
 							},
 						},
@@ -1789,17 +1789,17 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleConstant",
-			pos:  position{line: 348, col: 1, offset: 8498},
+			pos:  position{line: 348, col: 1, offset: 8488},
 			expr: &actionExpr{
-				pos: position{line: 348, col: 18, offset: 8517},
+				pos: position{line: 348, col: 18, offset: 8507},
 				run: (*parser).callonDoubleConstant1,
 				expr: &seqExpr{
-					pos: position{line: 348, col: 18, offset: 8517},
+					pos: position{line: 348, col: 18, offset: 8507},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 348, col: 18, offset: 8517},
+							pos: position{line: 348, col: 18, offset: 8507},
 							expr: &charClassMatcher{
-								pos:        position{line: 348, col: 18, offset: 8517},
+								pos:        position{line: 348, col: 18, offset: 8507},
 								val:        "[+-]",
 								chars:      []rune{'+', '-'},
 								ignoreCase: false,
@@ -1807,38 +1807,38 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 348, col: 24, offset: 8523},
+							pos: position{line: 348, col: 24, offset: 8513},
 							expr: &ruleRefExpr{
-								pos:  position{line: 348, col: 24, offset: 8523},
+								pos:  position{line: 348, col: 24, offset: 8513},
 								name: "Digit",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 348, col: 31, offset: 8530},
+							pos:        position{line: 348, col: 31, offset: 8520},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 348, col: 35, offset: 8534},
+							pos: position{line: 348, col: 35, offset: 8524},
 							expr: &ruleRefExpr{
-								pos:  position{line: 348, col: 35, offset: 8534},
+								pos:  position{line: 348, col: 35, offset: 8524},
 								name: "Digit",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 348, col: 42, offset: 8541},
+							pos: position{line: 348, col: 42, offset: 8531},
 							expr: &seqExpr{
-								pos: position{line: 348, col: 44, offset: 8543},
+								pos: position{line: 348, col: 44, offset: 8533},
 								exprs: []interface{}{
 									&charClassMatcher{
-										pos:        position{line: 348, col: 44, offset: 8543},
+										pos:        position{line: 348, col: 44, offset: 8533},
 										val:        "['Ee']",
 										chars:      []rune{'\'', 'E', 'e', '\''},
 										ignoreCase: false,
 										inverted:   false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 348, col: 51, offset: 8550},
+										pos:  position{line: 348, col: 51, offset: 8540},
 										name: "IntConstant",
 									},
 								},
@@ -1850,47 +1850,47 @@ var g = &grammar{
 		},
 		{
 			name: "ConstList",
-			pos:  position{line: 352, col: 1, offset: 8617},
+			pos:  position{line: 352, col: 1, offset: 8607},
 			expr: &actionExpr{
-				pos: position{line: 352, col: 13, offset: 8631},
+				pos: position{line: 352, col: 13, offset: 8621},
 				run: (*parser).callonConstList1,
 				expr: &seqExpr{
-					pos: position{line: 352, col: 13, offset: 8631},
+					pos: position{line: 352, col: 13, offset: 8621},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 352, col: 13, offset: 8631},
+							pos:        position{line: 352, col: 13, offset: 8621},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 352, col: 17, offset: 8635},
+							pos:  position{line: 352, col: 17, offset: 8625},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 352, col: 20, offset: 8638},
+							pos:   position{line: 352, col: 20, offset: 8628},
 							label: "values",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 352, col: 27, offset: 8645},
+								pos: position{line: 352, col: 27, offset: 8635},
 								expr: &seqExpr{
-									pos: position{line: 352, col: 28, offset: 8646},
+									pos: position{line: 352, col: 28, offset: 8636},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 352, col: 28, offset: 8646},
+											pos:  position{line: 352, col: 28, offset: 8636},
 											name: "ConstValue",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 352, col: 39, offset: 8657},
+											pos:  position{line: 352, col: 39, offset: 8647},
 											name: "__",
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 352, col: 42, offset: 8660},
+											pos: position{line: 352, col: 42, offset: 8650},
 											expr: &ruleRefExpr{
-												pos:  position{line: 352, col: 42, offset: 8660},
+												pos:  position{line: 352, col: 42, offset: 8650},
 												name: "ListSeparator",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 352, col: 57, offset: 8675},
+											pos:  position{line: 352, col: 57, offset: 8665},
 											name: "__",
 										},
 									},
@@ -1898,11 +1898,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 352, col: 62, offset: 8680},
+							pos:  position{line: 352, col: 62, offset: 8670},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 352, col: 65, offset: 8683},
+							pos:        position{line: 352, col: 65, offset: 8673},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -1912,67 +1912,67 @@ var g = &grammar{
 		},
 		{
 			name: "ConstMap",
-			pos:  position{line: 361, col: 1, offset: 8856},
+			pos:  position{line: 361, col: 1, offset: 8846},
 			expr: &actionExpr{
-				pos: position{line: 361, col: 12, offset: 8869},
+				pos: position{line: 361, col: 12, offset: 8859},
 				run: (*parser).callonConstMap1,
 				expr: &seqExpr{
-					pos: position{line: 361, col: 12, offset: 8869},
+					pos: position{line: 361, col: 12, offset: 8859},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 361, col: 12, offset: 8869},
+							pos:        position{line: 361, col: 12, offset: 8859},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 361, col: 16, offset: 8873},
+							pos:  position{line: 361, col: 16, offset: 8863},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 361, col: 19, offset: 8876},
+							pos:   position{line: 361, col: 19, offset: 8866},
 							label: "values",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 361, col: 26, offset: 8883},
+								pos: position{line: 361, col: 26, offset: 8873},
 								expr: &seqExpr{
-									pos: position{line: 361, col: 27, offset: 8884},
+									pos: position{line: 361, col: 27, offset: 8874},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 361, col: 27, offset: 8884},
+											pos:  position{line: 361, col: 27, offset: 8874},
 											name: "ConstValue",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 361, col: 38, offset: 8895},
+											pos:  position{line: 361, col: 38, offset: 8885},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 361, col: 41, offset: 8898},
+											pos:        position{line: 361, col: 41, offset: 8888},
 											val:        ":",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 361, col: 45, offset: 8902},
+											pos:  position{line: 361, col: 45, offset: 8892},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 361, col: 48, offset: 8905},
+											pos:  position{line: 361, col: 48, offset: 8895},
 											name: "ConstValue",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 361, col: 59, offset: 8916},
+											pos:  position{line: 361, col: 59, offset: 8906},
 											name: "__",
 										},
 										&choiceExpr{
-											pos: position{line: 361, col: 63, offset: 8920},
+											pos: position{line: 361, col: 63, offset: 8910},
 											alternatives: []interface{}{
 												&litMatcher{
-													pos:        position{line: 361, col: 63, offset: 8920},
+													pos:        position{line: 361, col: 63, offset: 8910},
 													val:        ",",
 													ignoreCase: false,
 												},
 												&andExpr{
-													pos: position{line: 361, col: 69, offset: 8926},
+													pos: position{line: 361, col: 69, offset: 8916},
 													expr: &litMatcher{
-														pos:        position{line: 361, col: 70, offset: 8927},
+														pos:        position{line: 361, col: 70, offset: 8917},
 														val:        "}",
 														ignoreCase: false,
 													},
@@ -1980,7 +1980,7 @@ var g = &grammar{
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 361, col: 75, offset: 8932},
+											pos:  position{line: 361, col: 75, offset: 8922},
 											name: "__",
 										},
 									},
@@ -1988,7 +1988,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 361, col: 80, offset: 8937},
+							pos:        position{line: 361, col: 80, offset: 8927},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -1998,33 +1998,33 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 377, col: 1, offset: 9183},
+			pos:  position{line: 377, col: 1, offset: 9173},
 			expr: &actionExpr{
-				pos: position{line: 377, col: 11, offset: 9195},
+				pos: position{line: 377, col: 11, offset: 9185},
 				run: (*parser).callonLiteral1,
 				expr: &choiceExpr{
-					pos: position{line: 377, col: 12, offset: 9196},
+					pos: position{line: 377, col: 12, offset: 9186},
 					alternatives: []interface{}{
 						&seqExpr{
-							pos: position{line: 377, col: 13, offset: 9197},
+							pos: position{line: 377, col: 13, offset: 9187},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 377, col: 13, offset: 9197},
+									pos:        position{line: 377, col: 13, offset: 9187},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 377, col: 17, offset: 9201},
+									pos: position{line: 377, col: 17, offset: 9191},
 									expr: &choiceExpr{
-										pos: position{line: 377, col: 18, offset: 9202},
+										pos: position{line: 377, col: 18, offset: 9192},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 377, col: 18, offset: 9202},
+												pos:        position{line: 377, col: 18, offset: 9192},
 												val:        "\\\"",
 												ignoreCase: false,
 											},
 											&charClassMatcher{
-												pos:        position{line: 377, col: 25, offset: 9209},
+												pos:        position{line: 377, col: 25, offset: 9199},
 												val:        "[^\"]",
 												chars:      []rune{'"'},
 												ignoreCase: false,
@@ -2034,32 +2034,32 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 377, col: 32, offset: 9216},
+									pos:        position{line: 377, col: 32, offset: 9206},
 									val:        "\"",
 									ignoreCase: false,
 								},
 							},
 						},
 						&seqExpr{
-							pos: position{line: 377, col: 40, offset: 9224},
+							pos: position{line: 377, col: 40, offset: 9214},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 377, col: 40, offset: 9224},
+									pos:        position{line: 377, col: 40, offset: 9214},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 377, col: 45, offset: 9229},
+									pos: position{line: 377, col: 45, offset: 9219},
 									expr: &choiceExpr{
-										pos: position{line: 377, col: 46, offset: 9230},
+										pos: position{line: 377, col: 46, offset: 9220},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 377, col: 46, offset: 9230},
+												pos:        position{line: 377, col: 46, offset: 9220},
 												val:        "\\'",
 												ignoreCase: false,
 											},
 											&charClassMatcher{
-												pos:        position{line: 377, col: 53, offset: 9237},
+												pos:        position{line: 377, col: 53, offset: 9227},
 												val:        "[^']",
 												chars:      []rune{'\''},
 												ignoreCase: false,
@@ -2069,7 +2069,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 377, col: 60, offset: 9244},
+									pos:        position{line: 377, col: 60, offset: 9234},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -2081,24 +2081,24 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 384, col: 1, offset: 9445},
+			pos:  position{line: 384, col: 1, offset: 9435},
 			expr: &actionExpr{
-				pos: position{line: 384, col: 14, offset: 9460},
+				pos: position{line: 384, col: 14, offset: 9450},
 				run: (*parser).callonIdentifier1,
 				expr: &seqExpr{
-					pos: position{line: 384, col: 14, offset: 9460},
+					pos: position{line: 384, col: 14, offset: 9450},
 					exprs: []interface{}{
 						&oneOrMoreExpr{
-							pos: position{line: 384, col: 14, offset: 9460},
+							pos: position{line: 384, col: 14, offset: 9450},
 							expr: &choiceExpr{
-								pos: position{line: 384, col: 15, offset: 9461},
+								pos: position{line: 384, col: 15, offset: 9451},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 384, col: 15, offset: 9461},
+										pos:  position{line: 384, col: 15, offset: 9451},
 										name: "Letter",
 									},
 									&litMatcher{
-										pos:        position{line: 384, col: 24, offset: 9470},
+										pos:        position{line: 384, col: 24, offset: 9460},
 										val:        "_",
 										ignoreCase: false,
 									},
@@ -2106,20 +2106,20 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 384, col: 30, offset: 9476},
+							pos: position{line: 384, col: 30, offset: 9466},
 							expr: &choiceExpr{
-								pos: position{line: 384, col: 31, offset: 9477},
+								pos: position{line: 384, col: 31, offset: 9467},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 384, col: 31, offset: 9477},
+										pos:  position{line: 384, col: 31, offset: 9467},
 										name: "Letter",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 384, col: 40, offset: 9486},
+										pos:  position{line: 384, col: 40, offset: 9476},
 										name: "Digit",
 									},
 									&charClassMatcher{
-										pos:        position{line: 384, col: 48, offset: 9494},
+										pos:        position{line: 384, col: 48, offset: 9484},
 										val:        "[._]",
 										chars:      []rune{'.', '_'},
 										ignoreCase: false,
@@ -2134,9 +2134,9 @@ var g = &grammar{
 		},
 		{
 			name: "ListSeparator",
-			pos:  position{line: 388, col: 1, offset: 9546},
+			pos:  position{line: 388, col: 1, offset: 9536},
 			expr: &charClassMatcher{
-				pos:        position{line: 388, col: 17, offset: 9564},
+				pos:        position{line: 388, col: 17, offset: 9554},
 				val:        "[,;]",
 				chars:      []rune{',', ';'},
 				ignoreCase: false,
@@ -2145,9 +2145,9 @@ var g = &grammar{
 		},
 		{
 			name: "Letter",
-			pos:  position{line: 389, col: 1, offset: 9569},
+			pos:  position{line: 389, col: 1, offset: 9559},
 			expr: &charClassMatcher{
-				pos:        position{line: 389, col: 10, offset: 9580},
+				pos:        position{line: 389, col: 10, offset: 9570},
 				val:        "[A-Za-z]",
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
 				ignoreCase: false,
@@ -2156,9 +2156,9 @@ var g = &grammar{
 		},
 		{
 			name: "Digit",
-			pos:  position{line: 390, col: 1, offset: 9589},
+			pos:  position{line: 390, col: 1, offset: 9579},
 			expr: &charClassMatcher{
-				pos:        position{line: 390, col: 9, offset: 9599},
+				pos:        position{line: 390, col: 9, offset: 9589},
 				val:        "[0-9]",
 				ranges:     []rune{'0', '9'},
 				ignoreCase: false,
@@ -2167,23 +2167,23 @@ var g = &grammar{
 		},
 		{
 			name: "SourceChar",
-			pos:  position{line: 394, col: 1, offset: 9610},
+			pos:  position{line: 394, col: 1, offset: 9600},
 			expr: &anyMatcher{
-				line: 394, col: 14, offset: 9625,
+				line: 394, col: 14, offset: 9615,
 			},
 		},
 		{
 			name: "Comment",
-			pos:  position{line: 395, col: 1, offset: 9627},
+			pos:  position{line: 395, col: 1, offset: 9617},
 			expr: &choiceExpr{
-				pos: position{line: 395, col: 11, offset: 9639},
+				pos: position{line: 395, col: 11, offset: 9629},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 395, col: 11, offset: 9639},
+						pos:  position{line: 395, col: 11, offset: 9629},
 						name: "MultiLineComment",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 395, col: 30, offset: 9658},
+						pos:  position{line: 395, col: 30, offset: 9648},
 						name: "SingleLineComment",
 					},
 				},
@@ -2191,37 +2191,37 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 396, col: 1, offset: 9676},
+			pos:  position{line: 396, col: 1, offset: 9666},
 			expr: &seqExpr{
-				pos: position{line: 396, col: 20, offset: 9697},
+				pos: position{line: 396, col: 20, offset: 9687},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 396, col: 20, offset: 9697},
+						pos:        position{line: 396, col: 20, offset: 9687},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 396, col: 25, offset: 9702},
+						pos: position{line: 396, col: 25, offset: 9692},
 						expr: &seqExpr{
-							pos: position{line: 396, col: 27, offset: 9704},
+							pos: position{line: 396, col: 27, offset: 9694},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 396, col: 27, offset: 9704},
+									pos: position{line: 396, col: 27, offset: 9694},
 									expr: &litMatcher{
-										pos:        position{line: 396, col: 28, offset: 9705},
+										pos:        position{line: 396, col: 28, offset: 9695},
 										val:        "*/",
 										ignoreCase: false,
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 396, col: 33, offset: 9710},
+									pos:  position{line: 396, col: 33, offset: 9700},
 									name: "SourceChar",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 396, col: 47, offset: 9724},
+						pos:        position{line: 396, col: 47, offset: 9714},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -2230,46 +2230,46 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineCommentNoLineTerminator",
-			pos:  position{line: 397, col: 1, offset: 9729},
+			pos:  position{line: 397, col: 1, offset: 9719},
 			expr: &seqExpr{
-				pos: position{line: 397, col: 36, offset: 9766},
+				pos: position{line: 397, col: 36, offset: 9756},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 397, col: 36, offset: 9766},
+						pos:        position{line: 397, col: 36, offset: 9756},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 397, col: 41, offset: 9771},
+						pos: position{line: 397, col: 41, offset: 9761},
 						expr: &seqExpr{
-							pos: position{line: 397, col: 43, offset: 9773},
+							pos: position{line: 397, col: 43, offset: 9763},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 397, col: 43, offset: 9773},
+									pos: position{line: 397, col: 43, offset: 9763},
 									expr: &choiceExpr{
-										pos: position{line: 397, col: 46, offset: 9776},
+										pos: position{line: 397, col: 46, offset: 9766},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 397, col: 46, offset: 9776},
+												pos:        position{line: 397, col: 46, offset: 9766},
 												val:        "*/",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 397, col: 53, offset: 9783},
+												pos:  position{line: 397, col: 53, offset: 9773},
 												name: "EOL",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 397, col: 59, offset: 9789},
+									pos:  position{line: 397, col: 59, offset: 9779},
 									name: "SourceChar",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 397, col: 73, offset: 9803},
+						pos:        position{line: 397, col: 73, offset: 9793},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -2278,32 +2278,32 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 398, col: 1, offset: 9808},
+			pos:  position{line: 398, col: 1, offset: 9798},
 			expr: &choiceExpr{
-				pos: position{line: 398, col: 21, offset: 9830},
+				pos: position{line: 398, col: 21, offset: 9820},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 398, col: 22, offset: 9831},
+						pos: position{line: 398, col: 22, offset: 9821},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 398, col: 22, offset: 9831},
+								pos:        position{line: 398, col: 22, offset: 9821},
 								val:        "//",
 								ignoreCase: false,
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 398, col: 27, offset: 9836},
+								pos: position{line: 398, col: 27, offset: 9826},
 								expr: &seqExpr{
-									pos: position{line: 398, col: 29, offset: 9838},
+									pos: position{line: 398, col: 29, offset: 9828},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 398, col: 29, offset: 9838},
+											pos: position{line: 398, col: 29, offset: 9828},
 											expr: &ruleRefExpr{
-												pos:  position{line: 398, col: 30, offset: 9839},
+												pos:  position{line: 398, col: 30, offset: 9829},
 												name: "EOL",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 398, col: 34, offset: 9843},
+											pos:  position{line: 398, col: 34, offset: 9833},
 											name: "SourceChar",
 										},
 									},
@@ -2312,27 +2312,27 @@ var g = &grammar{
 						},
 					},
 					&seqExpr{
-						pos: position{line: 398, col: 52, offset: 9861},
+						pos: position{line: 398, col: 52, offset: 9851},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 398, col: 52, offset: 9861},
+								pos:        position{line: 398, col: 52, offset: 9851},
 								val:        "#",
 								ignoreCase: false,
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 398, col: 56, offset: 9865},
+								pos: position{line: 398, col: 56, offset: 9855},
 								expr: &seqExpr{
-									pos: position{line: 398, col: 58, offset: 9867},
+									pos: position{line: 398, col: 58, offset: 9857},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 398, col: 58, offset: 9867},
+											pos: position{line: 398, col: 58, offset: 9857},
 											expr: &ruleRefExpr{
-												pos:  position{line: 398, col: 59, offset: 9868},
+												pos:  position{line: 398, col: 59, offset: 9858},
 												name: "EOL",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 398, col: 63, offset: 9872},
+											pos:  position{line: 398, col: 63, offset: 9862},
 											name: "SourceChar",
 										},
 									},
@@ -2345,22 +2345,22 @@ var g = &grammar{
 		},
 		{
 			name: "__",
-			pos:  position{line: 400, col: 1, offset: 9888},
+			pos:  position{line: 400, col: 1, offset: 9878},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 400, col: 6, offset: 9895},
+				pos: position{line: 400, col: 6, offset: 9885},
 				expr: &choiceExpr{
-					pos: position{line: 400, col: 8, offset: 9897},
+					pos: position{line: 400, col: 8, offset: 9887},
 					alternatives: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 400, col: 8, offset: 9897},
+							pos:  position{line: 400, col: 8, offset: 9887},
 							name: "Whitespace",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 400, col: 21, offset: 9910},
+							pos:  position{line: 400, col: 21, offset: 9900},
 							name: "EOL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 400, col: 27, offset: 9916},
+							pos:  position{line: 400, col: 27, offset: 9906},
 							name: "Comment",
 						},
 					},
@@ -2369,18 +2369,18 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 401, col: 1, offset: 9927},
+			pos:  position{line: 401, col: 1, offset: 9917},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 401, col: 5, offset: 9933},
+				pos: position{line: 401, col: 5, offset: 9923},
 				expr: &choiceExpr{
-					pos: position{line: 401, col: 7, offset: 9935},
+					pos: position{line: 401, col: 7, offset: 9925},
 					alternatives: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 401, col: 7, offset: 9935},
+							pos:  position{line: 401, col: 7, offset: 9925},
 							name: "Whitespace",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 401, col: 20, offset: 9948},
+							pos:  position{line: 401, col: 20, offset: 9938},
 							name: "MultiLineCommentNoLineTerminator",
 						},
 					},
@@ -2389,20 +2389,20 @@ var g = &grammar{
 		},
 		{
 			name: "WS",
-			pos:  position{line: 402, col: 1, offset: 9984},
+			pos:  position{line: 402, col: 1, offset: 9974},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 402, col: 6, offset: 9991},
+				pos: position{line: 402, col: 6, offset: 9981},
 				expr: &ruleRefExpr{
-					pos:  position{line: 402, col: 6, offset: 9991},
+					pos:  position{line: 402, col: 6, offset: 9981},
 					name: "Whitespace",
 				},
 			},
 		},
 		{
 			name: "Whitespace",
-			pos:  position{line: 404, col: 1, offset: 10004},
+			pos:  position{line: 404, col: 1, offset: 9994},
 			expr: &charClassMatcher{
-				pos:        position{line: 404, col: 14, offset: 10019},
+				pos:        position{line: 404, col: 14, offset: 10009},
 				val:        "[ \\t\\r]",
 				chars:      []rune{' ', '\t', '\r'},
 				ignoreCase: false,
@@ -2411,62 +2411,62 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 405, col: 1, offset: 10027},
+			pos:  position{line: 405, col: 1, offset: 10017},
 			expr: &litMatcher{
-				pos:        position{line: 405, col: 7, offset: 10035},
+				pos:        position{line: 405, col: 7, offset: 10025},
 				val:        "\n",
 				ignoreCase: false,
 			},
 		},
 		{
 			name: "EOS",
-			pos:  position{line: 406, col: 1, offset: 10040},
+			pos:  position{line: 406, col: 1, offset: 10030},
 			expr: &choiceExpr{
-				pos: position{line: 406, col: 7, offset: 10048},
+				pos: position{line: 406, col: 7, offset: 10038},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 406, col: 7, offset: 10048},
+						pos: position{line: 406, col: 7, offset: 10038},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 406, col: 7, offset: 10048},
+								pos:  position{line: 406, col: 7, offset: 10038},
 								name: "__",
 							},
 							&litMatcher{
-								pos:        position{line: 406, col: 10, offset: 10051},
+								pos:        position{line: 406, col: 10, offset: 10041},
 								val:        ";",
 								ignoreCase: false,
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 406, col: 16, offset: 10057},
+						pos: position{line: 406, col: 16, offset: 10047},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 406, col: 16, offset: 10057},
+								pos:  position{line: 406, col: 16, offset: 10047},
 								name: "_",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 406, col: 18, offset: 10059},
+								pos: position{line: 406, col: 18, offset: 10049},
 								expr: &ruleRefExpr{
-									pos:  position{line: 406, col: 18, offset: 10059},
+									pos:  position{line: 406, col: 18, offset: 10049},
 									name: "SingleLineComment",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 406, col: 37, offset: 10078},
+								pos:  position{line: 406, col: 37, offset: 10068},
 								name: "EOL",
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 406, col: 43, offset: 10084},
+						pos: position{line: 406, col: 43, offset: 10074},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 406, col: 43, offset: 10084},
+								pos:  position{line: 406, col: 43, offset: 10074},
 								name: "__",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 406, col: 46, offset: 10087},
+								pos:  position{line: 406, col: 46, offset: 10077},
 								name: "EOF",
 							},
 						},
@@ -2476,11 +2476,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 408, col: 1, offset: 10092},
+			pos:  position{line: 408, col: 1, offset: 10082},
 			expr: &notExpr{
-				pos: position{line: 408, col: 7, offset: 10100},
+				pos: position{line: 408, col: 7, offset: 10090},
 				expr: &anyMatcher{
-					line: 408, col: 8, offset: 10101,
+					line: 408, col: 8, offset: 10091,
 				},
 			},
 		},

--- a/parser/grammar.peg.go
+++ b/parser/grammar.peg.go
@@ -21,11 +21,6 @@ type namespace struct {
 	namespace string
 }
 
-type typeDef struct {
-	name string
-	typ  *Type
-}
-
 type exception *Struct
 
 type union *Struct
@@ -57,35 +52,42 @@ func unionToStruct(u union) *Struct {
 	return st
 }
 
+func toAnnotations(v interface{}) []*Annotation {
+	if v == nil {
+		return nil
+	}
+	return v.([]*Annotation)
+}
+
 var g = &grammar{
 	rules: []*rule{
 		{
 			name: "Grammar",
-			pos:  position{line: 54, col: 1, offset: 799},
+			pos:  position{line: 56, col: 1, offset: 860},
 			expr: &actionExpr{
-				pos: position{line: 54, col: 11, offset: 811},
+				pos: position{line: 56, col: 11, offset: 872},
 				run: (*parser).callonGrammar1,
 				expr: &seqExpr{
-					pos: position{line: 54, col: 11, offset: 811},
+					pos: position{line: 56, col: 11, offset: 872},
 					exprs: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 54, col: 11, offset: 811},
+							pos:  position{line: 56, col: 11, offset: 872},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 54, col: 14, offset: 814},
+							pos:   position{line: 56, col: 14, offset: 875},
 							label: "statements",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 54, col: 25, offset: 825},
+								pos: position{line: 56, col: 25, offset: 886},
 								expr: &seqExpr{
-									pos: position{line: 54, col: 27, offset: 827},
+									pos: position{line: 56, col: 27, offset: 888},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 54, col: 27, offset: 827},
+											pos:  position{line: 56, col: 27, offset: 888},
 											name: "Statement",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 54, col: 37, offset: 837},
+											pos:  position{line: 56, col: 37, offset: 898},
 											name: "__",
 										},
 									},
@@ -93,14 +95,14 @@ var g = &grammar{
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 54, col: 44, offset: 844},
+							pos: position{line: 56, col: 44, offset: 905},
 							alternatives: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 54, col: 44, offset: 844},
+									pos:  position{line: 56, col: 44, offset: 905},
 									name: "EOF",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 54, col: 50, offset: 850},
+									pos:  position{line: 56, col: 50, offset: 911},
 									name: "SyntaxError",
 								},
 							},
@@ -111,43 +113,43 @@ var g = &grammar{
 		},
 		{
 			name: "SyntaxError",
-			pos:  position{line: 98, col: 1, offset: 2020},
+			pos:  position{line: 100, col: 1, offset: 2081},
 			expr: &actionExpr{
-				pos: position{line: 98, col: 15, offset: 2036},
+				pos: position{line: 100, col: 15, offset: 2097},
 				run: (*parser).callonSyntaxError1,
 				expr: &anyMatcher{
-					line: 98, col: 15, offset: 2036,
+					line: 100, col: 15, offset: 2097,
 				},
 			},
 		},
 		{
 			name: "Include",
-			pos:  position{line: 102, col: 1, offset: 2091},
+			pos:  position{line: 104, col: 1, offset: 2152},
 			expr: &actionExpr{
-				pos: position{line: 102, col: 11, offset: 2103},
+				pos: position{line: 104, col: 11, offset: 2164},
 				run: (*parser).callonInclude1,
 				expr: &seqExpr{
-					pos: position{line: 102, col: 11, offset: 2103},
+					pos: position{line: 104, col: 11, offset: 2164},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 102, col: 11, offset: 2103},
+							pos:        position{line: 104, col: 11, offset: 2164},
 							val:        "include",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 102, col: 21, offset: 2113},
+							pos:  position{line: 104, col: 21, offset: 2174},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 102, col: 23, offset: 2115},
+							pos:   position{line: 104, col: 23, offset: 2176},
 							label: "file",
 							expr: &ruleRefExpr{
-								pos:  position{line: 102, col: 28, offset: 2120},
+								pos:  position{line: 104, col: 28, offset: 2181},
 								name: "Literal",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 102, col: 36, offset: 2128},
+							pos:  position{line: 104, col: 36, offset: 2189},
 							name: "EOS",
 						},
 					},
@@ -156,44 +158,44 @@ var g = &grammar{
 		},
 		{
 			name: "Statement",
-			pos:  position{line: 106, col: 1, offset: 2173},
+			pos:  position{line: 108, col: 1, offset: 2234},
 			expr: &choiceExpr{
-				pos: position{line: 106, col: 13, offset: 2187},
+				pos: position{line: 108, col: 13, offset: 2248},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 106, col: 13, offset: 2187},
+						pos:  position{line: 108, col: 13, offset: 2248},
 						name: "Include",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 106, col: 23, offset: 2197},
+						pos:  position{line: 108, col: 23, offset: 2258},
 						name: "Namespace",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 106, col: 35, offset: 2209},
+						pos:  position{line: 108, col: 35, offset: 2270},
 						name: "Const",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 106, col: 43, offset: 2217},
+						pos:  position{line: 108, col: 43, offset: 2278},
 						name: "Enum",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 106, col: 50, offset: 2224},
+						pos:  position{line: 108, col: 50, offset: 2285},
 						name: "TypeDef",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 106, col: 60, offset: 2234},
+						pos:  position{line: 108, col: 60, offset: 2295},
 						name: "Struct",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 106, col: 69, offset: 2243},
+						pos:  position{line: 108, col: 69, offset: 2304},
 						name: "Exception",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 106, col: 81, offset: 2255},
+						pos:  position{line: 108, col: 81, offset: 2316},
 						name: "Union",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 106, col: 89, offset: 2263},
+						pos:  position{line: 108, col: 89, offset: 2324},
 						name: "Service",
 					},
 				},
@@ -201,29 +203,29 @@ var g = &grammar{
 		},
 		{
 			name: "Namespace",
-			pos:  position{line: 108, col: 1, offset: 2272},
+			pos:  position{line: 110, col: 1, offset: 2333},
 			expr: &actionExpr{
-				pos: position{line: 108, col: 13, offset: 2286},
+				pos: position{line: 110, col: 13, offset: 2347},
 				run: (*parser).callonNamespace1,
 				expr: &seqExpr{
-					pos: position{line: 108, col: 13, offset: 2286},
+					pos: position{line: 110, col: 13, offset: 2347},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 108, col: 13, offset: 2286},
+							pos:        position{line: 110, col: 13, offset: 2347},
 							val:        "namespace",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 108, col: 25, offset: 2298},
+							pos:  position{line: 110, col: 25, offset: 2359},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 108, col: 27, offset: 2300},
+							pos:   position{line: 110, col: 27, offset: 2361},
 							label: "scope",
 							expr: &oneOrMoreExpr{
-								pos: position{line: 108, col: 33, offset: 2306},
+								pos: position{line: 110, col: 33, offset: 2367},
 								expr: &charClassMatcher{
-									pos:        position{line: 108, col: 33, offset: 2306},
+									pos:        position{line: 110, col: 33, offset: 2367},
 									val:        "[a-z.-]",
 									chars:      []rune{'.', '-'},
 									ranges:     []rune{'a', 'z'},
@@ -233,19 +235,19 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 108, col: 42, offset: 2315},
+							pos:  position{line: 110, col: 42, offset: 2376},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 108, col: 44, offset: 2317},
+							pos:   position{line: 110, col: 44, offset: 2378},
 							label: "ns",
 							expr: &ruleRefExpr{
-								pos:  position{line: 108, col: 47, offset: 2320},
+								pos:  position{line: 110, col: 47, offset: 2381},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 108, col: 58, offset: 2331},
+							pos:  position{line: 110, col: 58, offset: 2392},
 							name: "EOS",
 						},
 					},
@@ -254,65 +256,65 @@ var g = &grammar{
 		},
 		{
 			name: "Const",
-			pos:  position{line: 115, col: 1, offset: 2442},
+			pos:  position{line: 117, col: 1, offset: 2503},
 			expr: &actionExpr{
-				pos: position{line: 115, col: 9, offset: 2452},
+				pos: position{line: 117, col: 9, offset: 2513},
 				run: (*parser).callonConst1,
 				expr: &seqExpr{
-					pos: position{line: 115, col: 9, offset: 2452},
+					pos: position{line: 117, col: 9, offset: 2513},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 115, col: 9, offset: 2452},
+							pos:        position{line: 117, col: 9, offset: 2513},
 							val:        "const",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 115, col: 17, offset: 2460},
+							pos:  position{line: 117, col: 17, offset: 2521},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 115, col: 19, offset: 2462},
+							pos:   position{line: 117, col: 19, offset: 2523},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 115, col: 23, offset: 2466},
+								pos:  position{line: 117, col: 23, offset: 2527},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 115, col: 33, offset: 2476},
+							pos:  position{line: 117, col: 33, offset: 2537},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 115, col: 35, offset: 2478},
+							pos:   position{line: 117, col: 35, offset: 2539},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 115, col: 40, offset: 2483},
+								pos:  position{line: 117, col: 40, offset: 2544},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 115, col: 51, offset: 2494},
+							pos:  position{line: 117, col: 51, offset: 2555},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 115, col: 54, offset: 2497},
+							pos:        position{line: 117, col: 54, offset: 2558},
 							val:        "=",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 115, col: 58, offset: 2501},
+							pos:  position{line: 117, col: 58, offset: 2562},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 115, col: 61, offset: 2504},
+							pos:   position{line: 117, col: 61, offset: 2565},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 115, col: 67, offset: 2510},
+								pos:  position{line: 117, col: 67, offset: 2571},
 								name: "ConstValue",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 115, col: 78, offset: 2521},
+							pos:  position{line: 117, col: 78, offset: 2582},
 							name: "EOS",
 						},
 					},
@@ -321,57 +323,57 @@ var g = &grammar{
 		},
 		{
 			name: "Enum",
-			pos:  position{line: 123, col: 1, offset: 2629},
+			pos:  position{line: 125, col: 1, offset: 2690},
 			expr: &actionExpr{
-				pos: position{line: 123, col: 8, offset: 2638},
+				pos: position{line: 125, col: 8, offset: 2699},
 				run: (*parser).callonEnum1,
 				expr: &seqExpr{
-					pos: position{line: 123, col: 8, offset: 2638},
+					pos: position{line: 125, col: 8, offset: 2699},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 123, col: 8, offset: 2638},
+							pos:        position{line: 125, col: 8, offset: 2699},
 							val:        "enum",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 123, col: 15, offset: 2645},
+							pos:  position{line: 125, col: 15, offset: 2706},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 123, col: 17, offset: 2647},
+							pos:   position{line: 125, col: 17, offset: 2708},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 123, col: 22, offset: 2652},
+								pos:  position{line: 125, col: 22, offset: 2713},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 123, col: 33, offset: 2663},
+							pos:  position{line: 125, col: 33, offset: 2724},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 123, col: 36, offset: 2666},
+							pos:        position{line: 125, col: 36, offset: 2727},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 123, col: 40, offset: 2670},
+							pos:  position{line: 125, col: 40, offset: 2731},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 123, col: 43, offset: 2673},
+							pos:   position{line: 125, col: 43, offset: 2734},
 							label: "values",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 123, col: 50, offset: 2680},
+								pos: position{line: 125, col: 50, offset: 2741},
 								expr: &seqExpr{
-									pos: position{line: 123, col: 51, offset: 2681},
+									pos: position{line: 125, col: 51, offset: 2742},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 123, col: 51, offset: 2681},
+											pos:  position{line: 125, col: 51, offset: 2742},
 											name: "EnumValue",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 123, col: 61, offset: 2691},
+											pos:  position{line: 125, col: 61, offset: 2752},
 											name: "__",
 										},
 									},
@@ -379,12 +381,12 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 123, col: 66, offset: 2696},
+							pos:        position{line: 125, col: 66, offset: 2757},
 							val:        "}",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 123, col: 70, offset: 2700},
+							pos:  position{line: 125, col: 70, offset: 2761},
 							name: "EOS",
 						},
 					},
@@ -393,44 +395,44 @@ var g = &grammar{
 		},
 		{
 			name: "EnumValue",
-			pos:  position{line: 146, col: 1, offset: 3216},
+			pos:  position{line: 148, col: 1, offset: 3277},
 			expr: &actionExpr{
-				pos: position{line: 146, col: 13, offset: 3230},
+				pos: position{line: 148, col: 13, offset: 3291},
 				run: (*parser).callonEnumValue1,
 				expr: &seqExpr{
-					pos: position{line: 146, col: 13, offset: 3230},
+					pos: position{line: 148, col: 13, offset: 3291},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 146, col: 13, offset: 3230},
+							pos:   position{line: 148, col: 13, offset: 3291},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 146, col: 18, offset: 3235},
+								pos:  position{line: 148, col: 18, offset: 3296},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 146, col: 29, offset: 3246},
+							pos:  position{line: 148, col: 29, offset: 3307},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 146, col: 31, offset: 3248},
+							pos:   position{line: 148, col: 31, offset: 3309},
 							label: "value",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 146, col: 37, offset: 3254},
+								pos: position{line: 148, col: 37, offset: 3315},
 								expr: &seqExpr{
-									pos: position{line: 146, col: 38, offset: 3255},
+									pos: position{line: 148, col: 38, offset: 3316},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 146, col: 38, offset: 3255},
+											pos:        position{line: 148, col: 38, offset: 3316},
 											val:        "=",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 146, col: 42, offset: 3259},
+											pos:  position{line: 148, col: 42, offset: 3320},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 146, col: 44, offset: 3261},
+											pos:  position{line: 148, col: 44, offset: 3322},
 											name: "IntConstant",
 										},
 									},
@@ -438,9 +440,16 @@ var g = &grammar{
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 146, col: 58, offset: 3275},
+							pos: position{line: 148, col: 58, offset: 3336},
 							expr: &ruleRefExpr{
-								pos:  position{line: 146, col: 58, offset: 3275},
+								pos:  position{line: 148, col: 58, offset: 3336},
+								name: "TypeAnnotations",
+							},
+						},
+						&zeroOrOneExpr{
+							pos: position{line: 148, col: 75, offset: 3353},
+							expr: &ruleRefExpr{
+								pos:  position{line: 148, col: 75, offset: 3353},
 								name: "ListSeparator",
 							},
 						},
@@ -450,44 +459,59 @@ var g = &grammar{
 		},
 		{
 			name: "TypeDef",
-			pos:  position{line: 157, col: 1, offset: 3454},
+			pos:  position{line: 159, col: 1, offset: 3532},
 			expr: &actionExpr{
-				pos: position{line: 157, col: 11, offset: 3466},
+				pos: position{line: 159, col: 11, offset: 3544},
 				run: (*parser).callonTypeDef1,
 				expr: &seqExpr{
-					pos: position{line: 157, col: 11, offset: 3466},
+					pos: position{line: 159, col: 11, offset: 3544},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 157, col: 11, offset: 3466},
+							pos:        position{line: 159, col: 11, offset: 3544},
 							val:        "typedef",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 157, col: 21, offset: 3476},
+							pos:  position{line: 159, col: 21, offset: 3554},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 157, col: 23, offset: 3478},
+							pos:   position{line: 159, col: 23, offset: 3556},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 157, col: 27, offset: 3482},
+								pos:  position{line: 159, col: 27, offset: 3560},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 157, col: 37, offset: 3492},
+							pos:  position{line: 159, col: 37, offset: 3570},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 157, col: 39, offset: 3494},
+							pos:   position{line: 159, col: 39, offset: 3572},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 157, col: 44, offset: 3499},
+								pos:  position{line: 159, col: 44, offset: 3577},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 157, col: 55, offset: 3510},
+							pos:  position{line: 159, col: 55, offset: 3588},
+							name: "_",
+						},
+						&labeledExpr{
+							pos:   position{line: 159, col: 57, offset: 3590},
+							label: "annotations",
+							expr: &zeroOrOneExpr{
+								pos: position{line: 159, col: 69, offset: 3602},
+								expr: &ruleRefExpr{
+									pos:  position{line: 159, col: 69, offset: 3602},
+									name: "TypeAnnotations",
+								},
+							},
+						},
+						&ruleRefExpr{
+							pos:  position{line: 159, col: 86, offset: 3619},
 							name: "EOS",
 						},
 					},
@@ -496,27 +520,27 @@ var g = &grammar{
 		},
 		{
 			name: "Struct",
-			pos:  position{line: 164, col: 1, offset: 3600},
+			pos:  position{line: 168, col: 1, offset: 3755},
 			expr: &actionExpr{
-				pos: position{line: 164, col: 10, offset: 3611},
+				pos: position{line: 168, col: 10, offset: 3766},
 				run: (*parser).callonStruct1,
 				expr: &seqExpr{
-					pos: position{line: 164, col: 10, offset: 3611},
+					pos: position{line: 168, col: 10, offset: 3766},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 164, col: 10, offset: 3611},
+							pos:        position{line: 168, col: 10, offset: 3766},
 							val:        "struct",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 164, col: 19, offset: 3620},
+							pos:  position{line: 168, col: 19, offset: 3775},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 164, col: 21, offset: 3622},
+							pos:   position{line: 168, col: 21, offset: 3777},
 							label: "st",
 							expr: &ruleRefExpr{
-								pos:  position{line: 164, col: 24, offset: 3625},
+								pos:  position{line: 168, col: 24, offset: 3780},
 								name: "StructLike",
 							},
 						},
@@ -526,27 +550,27 @@ var g = &grammar{
 		},
 		{
 			name: "Exception",
-			pos:  position{line: 165, col: 1, offset: 3665},
+			pos:  position{line: 169, col: 1, offset: 3820},
 			expr: &actionExpr{
-				pos: position{line: 165, col: 13, offset: 3679},
+				pos: position{line: 169, col: 13, offset: 3834},
 				run: (*parser).callonException1,
 				expr: &seqExpr{
-					pos: position{line: 165, col: 13, offset: 3679},
+					pos: position{line: 169, col: 13, offset: 3834},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 165, col: 13, offset: 3679},
+							pos:        position{line: 169, col: 13, offset: 3834},
 							val:        "exception",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 165, col: 25, offset: 3691},
+							pos:  position{line: 169, col: 25, offset: 3846},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 165, col: 27, offset: 3693},
+							pos:   position{line: 169, col: 27, offset: 3848},
 							label: "st",
 							expr: &ruleRefExpr{
-								pos:  position{line: 165, col: 30, offset: 3696},
+								pos:  position{line: 169, col: 30, offset: 3851},
 								name: "StructLike",
 							},
 						},
@@ -556,27 +580,27 @@ var g = &grammar{
 		},
 		{
 			name: "Union",
-			pos:  position{line: 166, col: 1, offset: 3747},
+			pos:  position{line: 170, col: 1, offset: 3902},
 			expr: &actionExpr{
-				pos: position{line: 166, col: 9, offset: 3757},
+				pos: position{line: 170, col: 9, offset: 3912},
 				run: (*parser).callonUnion1,
 				expr: &seqExpr{
-					pos: position{line: 166, col: 9, offset: 3757},
+					pos: position{line: 170, col: 9, offset: 3912},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 166, col: 9, offset: 3757},
+							pos:        position{line: 170, col: 9, offset: 3912},
 							val:        "union",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 166, col: 17, offset: 3765},
+							pos:  position{line: 170, col: 17, offset: 3920},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 166, col: 19, offset: 3767},
+							pos:   position{line: 170, col: 19, offset: 3922},
 							label: "st",
 							expr: &ruleRefExpr{
-								pos:  position{line: 166, col: 22, offset: 3770},
+								pos:  position{line: 170, col: 22, offset: 3925},
 								name: "StructLike",
 							},
 						},
@@ -586,49 +610,49 @@ var g = &grammar{
 		},
 		{
 			name: "StructLike",
-			pos:  position{line: 167, col: 1, offset: 3817},
+			pos:  position{line: 171, col: 1, offset: 3972},
 			expr: &actionExpr{
-				pos: position{line: 167, col: 14, offset: 3832},
+				pos: position{line: 171, col: 14, offset: 3987},
 				run: (*parser).callonStructLike1,
 				expr: &seqExpr{
-					pos: position{line: 167, col: 14, offset: 3832},
+					pos: position{line: 171, col: 14, offset: 3987},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 167, col: 14, offset: 3832},
+							pos:   position{line: 171, col: 14, offset: 3987},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 167, col: 19, offset: 3837},
+								pos:  position{line: 171, col: 19, offset: 3992},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 167, col: 30, offset: 3848},
+							pos:  position{line: 171, col: 30, offset: 4003},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 167, col: 33, offset: 3851},
+							pos:        position{line: 171, col: 33, offset: 4006},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 167, col: 37, offset: 3855},
+							pos:  position{line: 171, col: 37, offset: 4010},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 167, col: 40, offset: 3858},
+							pos:   position{line: 171, col: 40, offset: 4013},
 							label: "fields",
 							expr: &ruleRefExpr{
-								pos:  position{line: 167, col: 47, offset: 3865},
+								pos:  position{line: 171, col: 47, offset: 4020},
 								name: "FieldList",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 167, col: 57, offset: 3875},
+							pos:        position{line: 171, col: 57, offset: 4030},
 							val:        "}",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 167, col: 61, offset: 3879},
+							pos:  position{line: 171, col: 61, offset: 4034},
 							name: "EOS",
 						},
 					},
@@ -637,24 +661,24 @@ var g = &grammar{
 		},
 		{
 			name: "FieldList",
-			pos:  position{line: 177, col: 1, offset: 4013},
+			pos:  position{line: 181, col: 1, offset: 4168},
 			expr: &actionExpr{
-				pos: position{line: 177, col: 13, offset: 4027},
+				pos: position{line: 181, col: 13, offset: 4182},
 				run: (*parser).callonFieldList1,
 				expr: &labeledExpr{
-					pos:   position{line: 177, col: 13, offset: 4027},
+					pos:   position{line: 181, col: 13, offset: 4182},
 					label: "fields",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 177, col: 20, offset: 4034},
+						pos: position{line: 181, col: 20, offset: 4189},
 						expr: &seqExpr{
-							pos: position{line: 177, col: 21, offset: 4035},
+							pos: position{line: 181, col: 21, offset: 4190},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 177, col: 21, offset: 4035},
+									pos:  position{line: 181, col: 21, offset: 4190},
 									name: "Field",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 177, col: 27, offset: 4041},
+									pos:  position{line: 181, col: 27, offset: 4196},
 									name: "__",
 								},
 							},
@@ -665,92 +689,92 @@ var g = &grammar{
 		},
 		{
 			name: "Field",
-			pos:  position{line: 186, col: 1, offset: 4201},
+			pos:  position{line: 190, col: 1, offset: 4356},
 			expr: &actionExpr{
-				pos: position{line: 186, col: 9, offset: 4211},
+				pos: position{line: 190, col: 9, offset: 4366},
 				run: (*parser).callonField1,
 				expr: &seqExpr{
-					pos: position{line: 186, col: 9, offset: 4211},
+					pos: position{line: 190, col: 9, offset: 4366},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 186, col: 9, offset: 4211},
+							pos:   position{line: 190, col: 9, offset: 4366},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 186, col: 12, offset: 4214},
+								pos:  position{line: 190, col: 12, offset: 4369},
 								name: "IntConstant",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 186, col: 24, offset: 4226},
+							pos:  position{line: 190, col: 24, offset: 4381},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 186, col: 26, offset: 4228},
+							pos:        position{line: 190, col: 26, offset: 4383},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 186, col: 30, offset: 4232},
+							pos:  position{line: 190, col: 30, offset: 4387},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 186, col: 32, offset: 4234},
+							pos:   position{line: 190, col: 32, offset: 4389},
 							label: "req",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 186, col: 36, offset: 4238},
+								pos: position{line: 190, col: 36, offset: 4393},
 								expr: &ruleRefExpr{
-									pos:  position{line: 186, col: 36, offset: 4238},
+									pos:  position{line: 190, col: 36, offset: 4393},
 									name: "FieldReq",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 186, col: 46, offset: 4248},
+							pos:  position{line: 190, col: 46, offset: 4403},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 186, col: 48, offset: 4250},
+							pos:   position{line: 190, col: 48, offset: 4405},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 186, col: 52, offset: 4254},
+								pos:  position{line: 190, col: 52, offset: 4409},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 186, col: 62, offset: 4264},
+							pos:  position{line: 190, col: 62, offset: 4419},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 186, col: 64, offset: 4266},
+							pos:   position{line: 190, col: 64, offset: 4421},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 186, col: 69, offset: 4271},
+								pos:  position{line: 190, col: 69, offset: 4426},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 186, col: 80, offset: 4282},
+							pos:  position{line: 190, col: 80, offset: 4437},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 186, col: 83, offset: 4285},
+							pos:   position{line: 190, col: 83, offset: 4440},
 							label: "def",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 186, col: 87, offset: 4289},
+								pos: position{line: 190, col: 87, offset: 4444},
 								expr: &seqExpr{
-									pos: position{line: 186, col: 88, offset: 4290},
+									pos: position{line: 190, col: 88, offset: 4445},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 186, col: 88, offset: 4290},
+											pos:        position{line: 190, col: 88, offset: 4445},
 											val:        "=",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 186, col: 92, offset: 4294},
+											pos:  position{line: 190, col: 92, offset: 4449},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 186, col: 94, offset: 4296},
+											pos:  position{line: 190, col: 94, offset: 4451},
 											name: "ConstValue",
 										},
 									},
@@ -758,9 +782,9 @@ var g = &grammar{
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 186, col: 107, offset: 4309},
+							pos: position{line: 190, col: 107, offset: 4464},
 							expr: &ruleRefExpr{
-								pos:  position{line: 186, col: 107, offset: 4309},
+								pos:  position{line: 190, col: 107, offset: 4464},
 								name: "ListSeparator",
 							},
 						},
@@ -770,20 +794,20 @@ var g = &grammar{
 		},
 		{
 			name: "FieldReq",
-			pos:  position{line: 201, col: 1, offset: 4569},
+			pos:  position{line: 205, col: 1, offset: 4724},
 			expr: &actionExpr{
-				pos: position{line: 201, col: 12, offset: 4582},
+				pos: position{line: 205, col: 12, offset: 4737},
 				run: (*parser).callonFieldReq1,
 				expr: &choiceExpr{
-					pos: position{line: 201, col: 13, offset: 4583},
+					pos: position{line: 205, col: 13, offset: 4738},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 201, col: 13, offset: 4583},
+							pos:        position{line: 205, col: 13, offset: 4738},
 							val:        "required",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 201, col: 26, offset: 4596},
+							pos:        position{line: 205, col: 26, offset: 4751},
 							val:        "optional",
 							ignoreCase: false,
 						},
@@ -793,57 +817,57 @@ var g = &grammar{
 		},
 		{
 			name: "Service",
-			pos:  position{line: 205, col: 1, offset: 4667},
+			pos:  position{line: 209, col: 1, offset: 4822},
 			expr: &actionExpr{
-				pos: position{line: 205, col: 11, offset: 4679},
+				pos: position{line: 209, col: 11, offset: 4834},
 				run: (*parser).callonService1,
 				expr: &seqExpr{
-					pos: position{line: 205, col: 11, offset: 4679},
+					pos: position{line: 209, col: 11, offset: 4834},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 205, col: 11, offset: 4679},
+							pos:        position{line: 209, col: 11, offset: 4834},
 							val:        "service",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 205, col: 21, offset: 4689},
+							pos:  position{line: 209, col: 21, offset: 4844},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 205, col: 23, offset: 4691},
+							pos:   position{line: 209, col: 23, offset: 4846},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 205, col: 28, offset: 4696},
+								pos:  position{line: 209, col: 28, offset: 4851},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 205, col: 39, offset: 4707},
+							pos:  position{line: 209, col: 39, offset: 4862},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 205, col: 41, offset: 4709},
+							pos:   position{line: 209, col: 41, offset: 4864},
 							label: "extends",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 205, col: 49, offset: 4717},
+								pos: position{line: 209, col: 49, offset: 4872},
 								expr: &seqExpr{
-									pos: position{line: 205, col: 50, offset: 4718},
+									pos: position{line: 209, col: 50, offset: 4873},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 205, col: 50, offset: 4718},
+											pos:        position{line: 209, col: 50, offset: 4873},
 											val:        "extends",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 205, col: 60, offset: 4728},
+											pos:  position{line: 209, col: 60, offset: 4883},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 205, col: 63, offset: 4731},
+											pos:  position{line: 209, col: 63, offset: 4886},
 											name: "Identifier",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 205, col: 74, offset: 4742},
+											pos:  position{line: 209, col: 74, offset: 4897},
 											name: "__",
 										},
 									},
@@ -851,32 +875,32 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 205, col: 79, offset: 4747},
+							pos:  position{line: 209, col: 79, offset: 4902},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 205, col: 82, offset: 4750},
+							pos:        position{line: 209, col: 82, offset: 4905},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 205, col: 86, offset: 4754},
+							pos:  position{line: 209, col: 86, offset: 4909},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 205, col: 89, offset: 4757},
+							pos:   position{line: 209, col: 89, offset: 4912},
 							label: "methods",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 205, col: 97, offset: 4765},
+								pos: position{line: 209, col: 97, offset: 4920},
 								expr: &seqExpr{
-									pos: position{line: 205, col: 98, offset: 4766},
+									pos: position{line: 209, col: 98, offset: 4921},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 205, col: 98, offset: 4766},
+											pos:  position{line: 209, col: 98, offset: 4921},
 											name: "Function",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 205, col: 107, offset: 4775},
+											pos:  position{line: 209, col: 107, offset: 4930},
 											name: "__",
 										},
 									},
@@ -884,21 +908,21 @@ var g = &grammar{
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 205, col: 113, offset: 4781},
+							pos: position{line: 209, col: 113, offset: 4936},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 205, col: 113, offset: 4781},
+									pos:        position{line: 209, col: 113, offset: 4936},
 									val:        "}",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 205, col: 119, offset: 4787},
+									pos:  position{line: 209, col: 119, offset: 4942},
 									name: "EndOfServiceError",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 205, col: 138, offset: 4806},
+							pos:  position{line: 209, col: 138, offset: 4961},
 							name: "EOS",
 						},
 					},
@@ -907,39 +931,39 @@ var g = &grammar{
 		},
 		{
 			name: "EndOfServiceError",
-			pos:  position{line: 220, col: 1, offset: 5147},
+			pos:  position{line: 224, col: 1, offset: 5302},
 			expr: &actionExpr{
-				pos: position{line: 220, col: 21, offset: 5169},
+				pos: position{line: 224, col: 21, offset: 5324},
 				run: (*parser).callonEndOfServiceError1,
 				expr: &anyMatcher{
-					line: 220, col: 21, offset: 5169,
+					line: 224, col: 21, offset: 5324,
 				},
 			},
 		},
 		{
 			name: "Function",
-			pos:  position{line: 224, col: 1, offset: 5235},
+			pos:  position{line: 228, col: 1, offset: 5390},
 			expr: &actionExpr{
-				pos: position{line: 224, col: 12, offset: 5248},
+				pos: position{line: 228, col: 12, offset: 5403},
 				run: (*parser).callonFunction1,
 				expr: &seqExpr{
-					pos: position{line: 224, col: 12, offset: 5248},
+					pos: position{line: 228, col: 12, offset: 5403},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 224, col: 12, offset: 5248},
+							pos:   position{line: 228, col: 12, offset: 5403},
 							label: "oneway",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 224, col: 19, offset: 5255},
+								pos: position{line: 228, col: 19, offset: 5410},
 								expr: &seqExpr{
-									pos: position{line: 224, col: 20, offset: 5256},
+									pos: position{line: 228, col: 20, offset: 5411},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 224, col: 20, offset: 5256},
+											pos:        position{line: 228, col: 20, offset: 5411},
 											val:        "oneway",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 224, col: 29, offset: 5265},
+											pos:  position{line: 228, col: 29, offset: 5420},
 											name: "__",
 										},
 									},
@@ -947,70 +971,70 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 224, col: 34, offset: 5270},
+							pos:   position{line: 228, col: 34, offset: 5425},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 224, col: 38, offset: 5274},
+								pos:  position{line: 228, col: 38, offset: 5429},
 								name: "FunctionType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 224, col: 51, offset: 5287},
+							pos:  position{line: 228, col: 51, offset: 5442},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 224, col: 54, offset: 5290},
+							pos:   position{line: 228, col: 54, offset: 5445},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 224, col: 59, offset: 5295},
+								pos:  position{line: 228, col: 59, offset: 5450},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 224, col: 70, offset: 5306},
+							pos:  position{line: 228, col: 70, offset: 5461},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 224, col: 72, offset: 5308},
+							pos:        position{line: 228, col: 72, offset: 5463},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 224, col: 76, offset: 5312},
+							pos:  position{line: 228, col: 76, offset: 5467},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 224, col: 79, offset: 5315},
+							pos:   position{line: 228, col: 79, offset: 5470},
 							label: "arguments",
 							expr: &ruleRefExpr{
-								pos:  position{line: 224, col: 89, offset: 5325},
+								pos:  position{line: 228, col: 89, offset: 5480},
 								name: "FieldList",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 224, col: 99, offset: 5335},
+							pos:        position{line: 228, col: 99, offset: 5490},
 							val:        ")",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 224, col: 103, offset: 5339},
+							pos:  position{line: 228, col: 103, offset: 5494},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 224, col: 106, offset: 5342},
+							pos:   position{line: 228, col: 106, offset: 5497},
 							label: "exceptions",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 224, col: 117, offset: 5353},
+								pos: position{line: 228, col: 117, offset: 5508},
 								expr: &ruleRefExpr{
-									pos:  position{line: 224, col: 117, offset: 5353},
+									pos:  position{line: 228, col: 117, offset: 5508},
 									name: "Throws",
 								},
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 224, col: 125, offset: 5361},
+							pos: position{line: 228, col: 125, offset: 5516},
 							expr: &ruleRefExpr{
-								pos:  position{line: 224, col: 125, offset: 5361},
+								pos:  position{line: 228, col: 125, offset: 5516},
 								name: "ListSeparator",
 							},
 						},
@@ -1020,23 +1044,23 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionType",
-			pos:  position{line: 247, col: 1, offset: 5742},
+			pos:  position{line: 251, col: 1, offset: 5897},
 			expr: &actionExpr{
-				pos: position{line: 247, col: 16, offset: 5759},
+				pos: position{line: 251, col: 16, offset: 5914},
 				run: (*parser).callonFunctionType1,
 				expr: &labeledExpr{
-					pos:   position{line: 247, col: 16, offset: 5759},
+					pos:   position{line: 251, col: 16, offset: 5914},
 					label: "typ",
 					expr: &choiceExpr{
-						pos: position{line: 247, col: 21, offset: 5764},
+						pos: position{line: 251, col: 21, offset: 5919},
 						alternatives: []interface{}{
 							&litMatcher{
-								pos:        position{line: 247, col: 21, offset: 5764},
+								pos:        position{line: 251, col: 21, offset: 5919},
 								val:        "void",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 247, col: 30, offset: 5773},
+								pos:  position{line: 251, col: 30, offset: 5928},
 								name: "FieldType",
 							},
 						},
@@ -1046,41 +1070,41 @@ var g = &grammar{
 		},
 		{
 			name: "Throws",
-			pos:  position{line: 254, col: 1, offset: 5880},
+			pos:  position{line: 258, col: 1, offset: 6035},
 			expr: &actionExpr{
-				pos: position{line: 254, col: 10, offset: 5891},
+				pos: position{line: 258, col: 10, offset: 6046},
 				run: (*parser).callonThrows1,
 				expr: &seqExpr{
-					pos: position{line: 254, col: 10, offset: 5891},
+					pos: position{line: 258, col: 10, offset: 6046},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 254, col: 10, offset: 5891},
+							pos:        position{line: 258, col: 10, offset: 6046},
 							val:        "throws",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 254, col: 19, offset: 5900},
+							pos:  position{line: 258, col: 19, offset: 6055},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 254, col: 22, offset: 5903},
+							pos:        position{line: 258, col: 22, offset: 6058},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 254, col: 26, offset: 5907},
+							pos:  position{line: 258, col: 26, offset: 6062},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 254, col: 29, offset: 5910},
+							pos:   position{line: 258, col: 29, offset: 6065},
 							label: "exceptions",
 							expr: &ruleRefExpr{
-								pos:  position{line: 254, col: 40, offset: 5921},
+								pos:  position{line: 258, col: 40, offset: 6076},
 								name: "FieldList",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 254, col: 50, offset: 5931},
+							pos:        position{line: 258, col: 50, offset: 6086},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -1090,26 +1114,26 @@ var g = &grammar{
 		},
 		{
 			name: "FieldType",
-			pos:  position{line: 258, col: 1, offset: 5964},
+			pos:  position{line: 262, col: 1, offset: 6119},
 			expr: &actionExpr{
-				pos: position{line: 258, col: 13, offset: 5978},
+				pos: position{line: 262, col: 13, offset: 6133},
 				run: (*parser).callonFieldType1,
 				expr: &labeledExpr{
-					pos:   position{line: 258, col: 13, offset: 5978},
+					pos:   position{line: 262, col: 13, offset: 6133},
 					label: "typ",
 					expr: &choiceExpr{
-						pos: position{line: 258, col: 18, offset: 5983},
+						pos: position{line: 262, col: 18, offset: 6138},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 258, col: 18, offset: 5983},
+								pos:  position{line: 262, col: 18, offset: 6138},
 								name: "BaseType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 258, col: 29, offset: 5994},
+								pos:  position{line: 262, col: 29, offset: 6149},
 								name: "ContainerType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 258, col: 45, offset: 6010},
+								pos:  position{line: 262, col: 45, offset: 6165},
 								name: "Identifier",
 							},
 						},
@@ -1119,22 +1143,22 @@ var g = &grammar{
 		},
 		{
 			name: "DefinitionType",
-			pos:  position{line: 265, col: 1, offset: 6120},
+			pos:  position{line: 269, col: 1, offset: 6275},
 			expr: &actionExpr{
-				pos: position{line: 265, col: 18, offset: 6139},
+				pos: position{line: 269, col: 18, offset: 6294},
 				run: (*parser).callonDefinitionType1,
 				expr: &labeledExpr{
-					pos:   position{line: 265, col: 18, offset: 6139},
+					pos:   position{line: 269, col: 18, offset: 6294},
 					label: "typ",
 					expr: &choiceExpr{
-						pos: position{line: 265, col: 23, offset: 6144},
+						pos: position{line: 269, col: 23, offset: 6299},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 265, col: 23, offset: 6144},
+								pos:  position{line: 269, col: 23, offset: 6299},
 								name: "BaseType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 265, col: 34, offset: 6155},
+								pos:  position{line: 269, col: 34, offset: 6310},
 								name: "ContainerType",
 							},
 						},
@@ -1144,50 +1168,86 @@ var g = &grammar{
 		},
 		{
 			name: "BaseType",
-			pos:  position{line: 269, col: 1, offset: 6192},
+			pos:  position{line: 273, col: 1, offset: 6347},
 			expr: &actionExpr{
-				pos: position{line: 269, col: 12, offset: 6205},
+				pos: position{line: 273, col: 12, offset: 6360},
 				run: (*parser).callonBaseType1,
+				expr: &seqExpr{
+					pos: position{line: 273, col: 12, offset: 6360},
+					exprs: []interface{}{
+						&labeledExpr{
+							pos:   position{line: 273, col: 12, offset: 6360},
+							label: "name",
+							expr: &ruleRefExpr{
+								pos:  position{line: 273, col: 17, offset: 6365},
+								name: "BaseTypeName",
+							},
+						},
+						&ruleRefExpr{
+							pos:  position{line: 273, col: 30, offset: 6378},
+							name: "__",
+						},
+						&labeledExpr{
+							pos:   position{line: 273, col: 33, offset: 6381},
+							label: "annotations",
+							expr: &zeroOrOneExpr{
+								pos: position{line: 273, col: 45, offset: 6393},
+								expr: &ruleRefExpr{
+									pos:  position{line: 273, col: 45, offset: 6393},
+									name: "TypeAnnotations",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "BaseTypeName",
+			pos:  position{line: 280, col: 1, offset: 6504},
+			expr: &actionExpr{
+				pos: position{line: 280, col: 16, offset: 6521},
+				run: (*parser).callonBaseTypeName1,
 				expr: &choiceExpr{
-					pos: position{line: 269, col: 13, offset: 6206},
+					pos: position{line: 280, col: 17, offset: 6522},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 269, col: 13, offset: 6206},
+							pos:        position{line: 280, col: 17, offset: 6522},
 							val:        "bool",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 269, col: 22, offset: 6215},
+							pos:        position{line: 280, col: 26, offset: 6531},
 							val:        "byte",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 269, col: 31, offset: 6224},
+							pos:        position{line: 280, col: 35, offset: 6540},
 							val:        "i16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 269, col: 39, offset: 6232},
+							pos:        position{line: 280, col: 43, offset: 6548},
 							val:        "i32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 269, col: 47, offset: 6240},
+							pos:        position{line: 280, col: 51, offset: 6556},
 							val:        "i64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 269, col: 55, offset: 6248},
+							pos:        position{line: 280, col: 59, offset: 6564},
 							val:        "double",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 269, col: 66, offset: 6259},
+							pos:        position{line: 280, col: 70, offset: 6575},
 							val:        "string",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 269, col: 77, offset: 6270},
+							pos:        position{line: 280, col: 81, offset: 6586},
 							val:        "binary",
 							ignoreCase: false,
 						},
@@ -1197,26 +1257,26 @@ var g = &grammar{
 		},
 		{
 			name: "ContainerType",
-			pos:  position{line: 273, col: 1, offset: 6327},
+			pos:  position{line: 284, col: 1, offset: 6630},
 			expr: &actionExpr{
-				pos: position{line: 273, col: 17, offset: 6345},
+				pos: position{line: 284, col: 17, offset: 6648},
 				run: (*parser).callonContainerType1,
 				expr: &labeledExpr{
-					pos:   position{line: 273, col: 17, offset: 6345},
+					pos:   position{line: 284, col: 17, offset: 6648},
 					label: "typ",
 					expr: &choiceExpr{
-						pos: position{line: 273, col: 22, offset: 6350},
+						pos: position{line: 284, col: 22, offset: 6653},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 273, col: 22, offset: 6350},
+								pos:  position{line: 284, col: 22, offset: 6653},
 								name: "MapType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 273, col: 32, offset: 6360},
+								pos:  position{line: 284, col: 32, offset: 6663},
 								name: "SetType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 273, col: 42, offset: 6370},
+								pos:  position{line: 284, col: 42, offset: 6673},
 								name: "ListType",
 							},
 						},
@@ -1226,75 +1286,90 @@ var g = &grammar{
 		},
 		{
 			name: "MapType",
-			pos:  position{line: 277, col: 1, offset: 6402},
+			pos:  position{line: 288, col: 1, offset: 6705},
 			expr: &actionExpr{
-				pos: position{line: 277, col: 11, offset: 6414},
+				pos: position{line: 288, col: 11, offset: 6717},
 				run: (*parser).callonMapType1,
 				expr: &seqExpr{
-					pos: position{line: 277, col: 11, offset: 6414},
+					pos: position{line: 288, col: 11, offset: 6717},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 277, col: 11, offset: 6414},
+							pos: position{line: 288, col: 11, offset: 6717},
 							expr: &ruleRefExpr{
-								pos:  position{line: 277, col: 11, offset: 6414},
+								pos:  position{line: 288, col: 11, offset: 6717},
 								name: "CppType",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 277, col: 20, offset: 6423},
+							pos:        position{line: 288, col: 20, offset: 6726},
 							val:        "map",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 277, col: 26, offset: 6429},
+							pos:  position{line: 288, col: 26, offset: 6732},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 277, col: 29, offset: 6432},
+							pos:        position{line: 288, col: 29, offset: 6735},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 277, col: 33, offset: 6436},
+							pos:  position{line: 288, col: 33, offset: 6739},
 							name: "WS",
 						},
 						&labeledExpr{
-							pos:   position{line: 277, col: 36, offset: 6439},
+							pos:   position{line: 288, col: 36, offset: 6742},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 277, col: 40, offset: 6443},
+								pos:  position{line: 288, col: 40, offset: 6746},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 277, col: 50, offset: 6453},
+							pos:  position{line: 288, col: 50, offset: 6756},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 277, col: 53, offset: 6456},
+							pos:        position{line: 288, col: 53, offset: 6759},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 277, col: 57, offset: 6460},
+							pos:  position{line: 288, col: 57, offset: 6763},
 							name: "WS",
 						},
 						&labeledExpr{
-							pos:   position{line: 277, col: 60, offset: 6463},
+							pos:   position{line: 288, col: 60, offset: 6766},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 277, col: 66, offset: 6469},
+								pos:  position{line: 288, col: 66, offset: 6772},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 277, col: 76, offset: 6479},
+							pos:  position{line: 288, col: 76, offset: 6782},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 277, col: 79, offset: 6482},
+							pos:        position{line: 288, col: 79, offset: 6785},
 							val:        ">",
 							ignoreCase: false,
+						},
+						&ruleRefExpr{
+							pos:  position{line: 288, col: 83, offset: 6789},
+							name: "__",
+						},
+						&labeledExpr{
+							pos:   position{line: 288, col: 86, offset: 6792},
+							label: "annotations",
+							expr: &zeroOrOneExpr{
+								pos: position{line: 288, col: 98, offset: 6804},
+								expr: &ruleRefExpr{
+									pos:  position{line: 288, col: 98, offset: 6804},
+									name: "TypeAnnotations",
+								},
+							},
 						},
 					},
 				},
@@ -1302,54 +1377,69 @@ var g = &grammar{
 		},
 		{
 			name: "SetType",
-			pos:  position{line: 285, col: 1, offset: 6581},
+			pos:  position{line: 297, col: 1, offset: 6959},
 			expr: &actionExpr{
-				pos: position{line: 285, col: 11, offset: 6593},
+				pos: position{line: 297, col: 11, offset: 6971},
 				run: (*parser).callonSetType1,
 				expr: &seqExpr{
-					pos: position{line: 285, col: 11, offset: 6593},
+					pos: position{line: 297, col: 11, offset: 6971},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 285, col: 11, offset: 6593},
+							pos: position{line: 297, col: 11, offset: 6971},
 							expr: &ruleRefExpr{
-								pos:  position{line: 285, col: 11, offset: 6593},
+								pos:  position{line: 297, col: 11, offset: 6971},
 								name: "CppType",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 285, col: 20, offset: 6602},
+							pos:        position{line: 297, col: 20, offset: 6980},
 							val:        "set",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 285, col: 26, offset: 6608},
+							pos:  position{line: 297, col: 26, offset: 6986},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 285, col: 29, offset: 6611},
+							pos:        position{line: 297, col: 29, offset: 6989},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 285, col: 33, offset: 6615},
+							pos:  position{line: 297, col: 33, offset: 6993},
 							name: "WS",
 						},
 						&labeledExpr{
-							pos:   position{line: 285, col: 36, offset: 6618},
+							pos:   position{line: 297, col: 36, offset: 6996},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 285, col: 40, offset: 6622},
+								pos:  position{line: 297, col: 40, offset: 7000},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 285, col: 50, offset: 6632},
+							pos:  position{line: 297, col: 50, offset: 7010},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 285, col: 53, offset: 6635},
+							pos:        position{line: 297, col: 53, offset: 7013},
 							val:        ">",
 							ignoreCase: false,
+						},
+						&ruleRefExpr{
+							pos:  position{line: 297, col: 57, offset: 7017},
+							name: "__",
+						},
+						&labeledExpr{
+							pos:   position{line: 297, col: 60, offset: 7020},
+							label: "annotations",
+							expr: &zeroOrOneExpr{
+								pos: position{line: 297, col: 72, offset: 7032},
+								expr: &ruleRefExpr{
+									pos:  position{line: 297, col: 72, offset: 7032},
+									name: "TypeAnnotations",
+								},
+							},
 						},
 					},
 				},
@@ -1357,47 +1447,62 @@ var g = &grammar{
 		},
 		{
 			name: "ListType",
-			pos:  position{line: 292, col: 1, offset: 6708},
+			pos:  position{line: 305, col: 1, offset: 7161},
 			expr: &actionExpr{
-				pos: position{line: 292, col: 12, offset: 6721},
+				pos: position{line: 305, col: 12, offset: 7174},
 				run: (*parser).callonListType1,
 				expr: &seqExpr{
-					pos: position{line: 292, col: 12, offset: 6721},
+					pos: position{line: 305, col: 12, offset: 7174},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 292, col: 12, offset: 6721},
+							pos:        position{line: 305, col: 12, offset: 7174},
 							val:        "list",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 292, col: 19, offset: 6728},
+							pos:  position{line: 305, col: 19, offset: 7181},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 292, col: 22, offset: 6731},
+							pos:        position{line: 305, col: 22, offset: 7184},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 292, col: 26, offset: 6735},
+							pos:  position{line: 305, col: 26, offset: 7188},
 							name: "WS",
 						},
 						&labeledExpr{
-							pos:   position{line: 292, col: 29, offset: 6738},
+							pos:   position{line: 305, col: 29, offset: 7191},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 292, col: 33, offset: 6742},
+								pos:  position{line: 305, col: 33, offset: 7195},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 292, col: 43, offset: 6752},
+							pos:  position{line: 305, col: 43, offset: 7205},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 292, col: 46, offset: 6755},
+							pos:        position{line: 305, col: 46, offset: 7208},
 							val:        ">",
 							ignoreCase: false,
+						},
+						&ruleRefExpr{
+							pos:  position{line: 305, col: 50, offset: 7212},
+							name: "__",
+						},
+						&labeledExpr{
+							pos:   position{line: 305, col: 53, offset: 7215},
+							label: "annotations",
+							expr: &zeroOrOneExpr{
+								pos: position{line: 305, col: 65, offset: 7227},
+								expr: &ruleRefExpr{
+									pos:  position{line: 305, col: 65, offset: 7227},
+									name: "TypeAnnotations",
+								},
+							},
 						},
 					},
 				},
@@ -1405,23 +1510,23 @@ var g = &grammar{
 		},
 		{
 			name: "CppType",
-			pos:  position{line: 299, col: 1, offset: 6829},
+			pos:  position{line: 313, col: 1, offset: 7357},
 			expr: &actionExpr{
-				pos: position{line: 299, col: 11, offset: 6841},
+				pos: position{line: 313, col: 11, offset: 7369},
 				run: (*parser).callonCppType1,
 				expr: &seqExpr{
-					pos: position{line: 299, col: 11, offset: 6841},
+					pos: position{line: 313, col: 11, offset: 7369},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 299, col: 11, offset: 6841},
+							pos:        position{line: 313, col: 11, offset: 7369},
 							val:        "cpp_type",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 299, col: 22, offset: 6852},
+							pos:   position{line: 313, col: 22, offset: 7380},
 							label: "cppType",
 							expr: &ruleRefExpr{
-								pos:  position{line: 299, col: 30, offset: 6860},
+								pos:  position{line: 313, col: 30, offset: 7388},
 								name: "Literal",
 							},
 						},
@@ -1431,50 +1536,157 @@ var g = &grammar{
 		},
 		{
 			name: "ConstValue",
-			pos:  position{line: 303, col: 1, offset: 6894},
+			pos:  position{line: 317, col: 1, offset: 7422},
 			expr: &choiceExpr{
-				pos: position{line: 303, col: 14, offset: 6909},
+				pos: position{line: 317, col: 14, offset: 7437},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 303, col: 14, offset: 6909},
+						pos:  position{line: 317, col: 14, offset: 7437},
 						name: "Literal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 303, col: 24, offset: 6919},
+						pos:  position{line: 317, col: 24, offset: 7447},
 						name: "DoubleConstant",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 303, col: 41, offset: 6936},
+						pos:  position{line: 317, col: 41, offset: 7464},
 						name: "IntConstant",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 303, col: 55, offset: 6950},
+						pos:  position{line: 317, col: 55, offset: 7478},
 						name: "ConstMap",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 303, col: 66, offset: 6961},
+						pos:  position{line: 317, col: 66, offset: 7489},
 						name: "ConstList",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 303, col: 78, offset: 6973},
+						pos:  position{line: 317, col: 78, offset: 7501},
 						name: "Identifier",
 					},
 				},
 			},
 		},
 		{
-			name: "IntConstant",
-			pos:  position{line: 305, col: 1, offset: 6985},
+			name: "TypeAnnotations",
+			pos:  position{line: 319, col: 1, offset: 7513},
 			expr: &actionExpr{
-				pos: position{line: 305, col: 15, offset: 7001},
+				pos: position{line: 319, col: 19, offset: 7533},
+				run: (*parser).callonTypeAnnotations1,
+				expr: &seqExpr{
+					pos: position{line: 319, col: 19, offset: 7533},
+					exprs: []interface{}{
+						&litMatcher{
+							pos:        position{line: 319, col: 19, offset: 7533},
+							val:        "(",
+							ignoreCase: false,
+						},
+						&ruleRefExpr{
+							pos:  position{line: 319, col: 23, offset: 7537},
+							name: "__",
+						},
+						&labeledExpr{
+							pos:   position{line: 319, col: 26, offset: 7540},
+							label: "annotations",
+							expr: &zeroOrMoreExpr{
+								pos: position{line: 319, col: 38, offset: 7552},
+								expr: &ruleRefExpr{
+									pos:  position{line: 319, col: 38, offset: 7552},
+									name: "TypeAnnotation",
+								},
+							},
+						},
+						&litMatcher{
+							pos:        position{line: 319, col: 54, offset: 7568},
+							val:        ")",
+							ignoreCase: false,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "TypeAnnotation",
+			pos:  position{line: 327, col: 1, offset: 7714},
+			expr: &actionExpr{
+				pos: position{line: 327, col: 18, offset: 7733},
+				run: (*parser).callonTypeAnnotation1,
+				expr: &seqExpr{
+					pos: position{line: 327, col: 18, offset: 7733},
+					exprs: []interface{}{
+						&labeledExpr{
+							pos:   position{line: 327, col: 18, offset: 7733},
+							label: "name",
+							expr: &ruleRefExpr{
+								pos:  position{line: 327, col: 23, offset: 7738},
+								name: "Identifier",
+							},
+						},
+						&ruleRefExpr{
+							pos:  position{line: 327, col: 34, offset: 7749},
+							name: "_",
+						},
+						&labeledExpr{
+							pos:   position{line: 327, col: 36, offset: 7751},
+							label: "value",
+							expr: &zeroOrOneExpr{
+								pos: position{line: 327, col: 42, offset: 7757},
+								expr: &actionExpr{
+									pos: position{line: 327, col: 43, offset: 7758},
+									run: (*parser).callonTypeAnnotation8,
+									expr: &seqExpr{
+										pos: position{line: 327, col: 43, offset: 7758},
+										exprs: []interface{}{
+											&litMatcher{
+												pos:        position{line: 327, col: 43, offset: 7758},
+												val:        "=",
+												ignoreCase: false,
+											},
+											&ruleRefExpr{
+												pos:  position{line: 327, col: 47, offset: 7762},
+												name: "__",
+											},
+											&labeledExpr{
+												pos:   position{line: 327, col: 50, offset: 7765},
+												label: "value",
+												expr: &ruleRefExpr{
+													pos:  position{line: 327, col: 56, offset: 7771},
+													name: "Literal",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						&zeroOrOneExpr{
+							pos: position{line: 327, col: 88, offset: 7803},
+							expr: &ruleRefExpr{
+								pos:  position{line: 327, col: 88, offset: 7803},
+								name: "ListSeparator",
+							},
+						},
+						&ruleRefExpr{
+							pos:  position{line: 327, col: 103, offset: 7818},
+							name: "__",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "IntConstant",
+			pos:  position{line: 338, col: 1, offset: 7981},
+			expr: &actionExpr{
+				pos: position{line: 338, col: 15, offset: 7997},
 				run: (*parser).callonIntConstant1,
 				expr: &seqExpr{
-					pos: position{line: 305, col: 15, offset: 7001},
+					pos: position{line: 338, col: 15, offset: 7997},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 305, col: 15, offset: 7001},
+							pos: position{line: 338, col: 15, offset: 7997},
 							expr: &charClassMatcher{
-								pos:        position{line: 305, col: 15, offset: 7001},
+								pos:        position{line: 338, col: 15, offset: 7997},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -1482,9 +1694,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 305, col: 21, offset: 7007},
+							pos: position{line: 338, col: 21, offset: 8003},
 							expr: &ruleRefExpr{
-								pos:  position{line: 305, col: 21, offset: 7007},
+								pos:  position{line: 338, col: 21, offset: 8003},
 								name: "Digit",
 							},
 						},
@@ -1494,17 +1706,17 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleConstant",
-			pos:  position{line: 309, col: 1, offset: 7068},
+			pos:  position{line: 342, col: 1, offset: 8064},
 			expr: &actionExpr{
-				pos: position{line: 309, col: 18, offset: 7087},
+				pos: position{line: 342, col: 18, offset: 8083},
 				run: (*parser).callonDoubleConstant1,
 				expr: &seqExpr{
-					pos: position{line: 309, col: 18, offset: 7087},
+					pos: position{line: 342, col: 18, offset: 8083},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 309, col: 18, offset: 7087},
+							pos: position{line: 342, col: 18, offset: 8083},
 							expr: &charClassMatcher{
-								pos:        position{line: 309, col: 18, offset: 7087},
+								pos:        position{line: 342, col: 18, offset: 8083},
 								val:        "[+-]",
 								chars:      []rune{'+', '-'},
 								ignoreCase: false,
@@ -1512,38 +1724,38 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 309, col: 24, offset: 7093},
+							pos: position{line: 342, col: 24, offset: 8089},
 							expr: &ruleRefExpr{
-								pos:  position{line: 309, col: 24, offset: 7093},
+								pos:  position{line: 342, col: 24, offset: 8089},
 								name: "Digit",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 309, col: 31, offset: 7100},
+							pos:        position{line: 342, col: 31, offset: 8096},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 309, col: 35, offset: 7104},
+							pos: position{line: 342, col: 35, offset: 8100},
 							expr: &ruleRefExpr{
-								pos:  position{line: 309, col: 35, offset: 7104},
+								pos:  position{line: 342, col: 35, offset: 8100},
 								name: "Digit",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 309, col: 42, offset: 7111},
+							pos: position{line: 342, col: 42, offset: 8107},
 							expr: &seqExpr{
-								pos: position{line: 309, col: 44, offset: 7113},
+								pos: position{line: 342, col: 44, offset: 8109},
 								exprs: []interface{}{
 									&charClassMatcher{
-										pos:        position{line: 309, col: 44, offset: 7113},
+										pos:        position{line: 342, col: 44, offset: 8109},
 										val:        "['Ee']",
 										chars:      []rune{'\'', 'E', 'e', '\''},
 										ignoreCase: false,
 										inverted:   false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 309, col: 51, offset: 7120},
+										pos:  position{line: 342, col: 51, offset: 8116},
 										name: "IntConstant",
 									},
 								},
@@ -1555,47 +1767,47 @@ var g = &grammar{
 		},
 		{
 			name: "ConstList",
-			pos:  position{line: 313, col: 1, offset: 7187},
+			pos:  position{line: 346, col: 1, offset: 8183},
 			expr: &actionExpr{
-				pos: position{line: 313, col: 13, offset: 7201},
+				pos: position{line: 346, col: 13, offset: 8197},
 				run: (*parser).callonConstList1,
 				expr: &seqExpr{
-					pos: position{line: 313, col: 13, offset: 7201},
+					pos: position{line: 346, col: 13, offset: 8197},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 313, col: 13, offset: 7201},
+							pos:        position{line: 346, col: 13, offset: 8197},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 313, col: 17, offset: 7205},
+							pos:  position{line: 346, col: 17, offset: 8201},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 313, col: 20, offset: 7208},
+							pos:   position{line: 346, col: 20, offset: 8204},
 							label: "values",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 313, col: 27, offset: 7215},
+								pos: position{line: 346, col: 27, offset: 8211},
 								expr: &seqExpr{
-									pos: position{line: 313, col: 28, offset: 7216},
+									pos: position{line: 346, col: 28, offset: 8212},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 313, col: 28, offset: 7216},
+											pos:  position{line: 346, col: 28, offset: 8212},
 											name: "ConstValue",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 313, col: 39, offset: 7227},
+											pos:  position{line: 346, col: 39, offset: 8223},
 											name: "__",
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 313, col: 42, offset: 7230},
+											pos: position{line: 346, col: 42, offset: 8226},
 											expr: &ruleRefExpr{
-												pos:  position{line: 313, col: 42, offset: 7230},
+												pos:  position{line: 346, col: 42, offset: 8226},
 												name: "ListSeparator",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 313, col: 57, offset: 7245},
+											pos:  position{line: 346, col: 57, offset: 8241},
 											name: "__",
 										},
 									},
@@ -1603,11 +1815,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 313, col: 62, offset: 7250},
+							pos:  position{line: 346, col: 62, offset: 8246},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 313, col: 65, offset: 7253},
+							pos:        position{line: 346, col: 65, offset: 8249},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -1617,67 +1829,67 @@ var g = &grammar{
 		},
 		{
 			name: "ConstMap",
-			pos:  position{line: 322, col: 1, offset: 7426},
+			pos:  position{line: 355, col: 1, offset: 8422},
 			expr: &actionExpr{
-				pos: position{line: 322, col: 12, offset: 7439},
+				pos: position{line: 355, col: 12, offset: 8435},
 				run: (*parser).callonConstMap1,
 				expr: &seqExpr{
-					pos: position{line: 322, col: 12, offset: 7439},
+					pos: position{line: 355, col: 12, offset: 8435},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 322, col: 12, offset: 7439},
+							pos:        position{line: 355, col: 12, offset: 8435},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 322, col: 16, offset: 7443},
+							pos:  position{line: 355, col: 16, offset: 8439},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 322, col: 19, offset: 7446},
+							pos:   position{line: 355, col: 19, offset: 8442},
 							label: "values",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 322, col: 26, offset: 7453},
+								pos: position{line: 355, col: 26, offset: 8449},
 								expr: &seqExpr{
-									pos: position{line: 322, col: 27, offset: 7454},
+									pos: position{line: 355, col: 27, offset: 8450},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 322, col: 27, offset: 7454},
+											pos:  position{line: 355, col: 27, offset: 8450},
 											name: "ConstValue",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 322, col: 38, offset: 7465},
+											pos:  position{line: 355, col: 38, offset: 8461},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 322, col: 41, offset: 7468},
+											pos:        position{line: 355, col: 41, offset: 8464},
 											val:        ":",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 322, col: 45, offset: 7472},
+											pos:  position{line: 355, col: 45, offset: 8468},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 322, col: 48, offset: 7475},
+											pos:  position{line: 355, col: 48, offset: 8471},
 											name: "ConstValue",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 322, col: 59, offset: 7486},
+											pos:  position{line: 355, col: 59, offset: 8482},
 											name: "__",
 										},
 										&choiceExpr{
-											pos: position{line: 322, col: 63, offset: 7490},
+											pos: position{line: 355, col: 63, offset: 8486},
 											alternatives: []interface{}{
 												&litMatcher{
-													pos:        position{line: 322, col: 63, offset: 7490},
+													pos:        position{line: 355, col: 63, offset: 8486},
 													val:        ",",
 													ignoreCase: false,
 												},
 												&andExpr{
-													pos: position{line: 322, col: 69, offset: 7496},
+													pos: position{line: 355, col: 69, offset: 8492},
 													expr: &litMatcher{
-														pos:        position{line: 322, col: 70, offset: 7497},
+														pos:        position{line: 355, col: 70, offset: 8493},
 														val:        "}",
 														ignoreCase: false,
 													},
@@ -1685,7 +1897,7 @@ var g = &grammar{
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 322, col: 75, offset: 7502},
+											pos:  position{line: 355, col: 75, offset: 8498},
 											name: "__",
 										},
 									},
@@ -1693,7 +1905,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 322, col: 80, offset: 7507},
+							pos:        position{line: 355, col: 80, offset: 8503},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -1703,33 +1915,33 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 338, col: 1, offset: 7753},
+			pos:  position{line: 371, col: 1, offset: 8749},
 			expr: &actionExpr{
-				pos: position{line: 338, col: 11, offset: 7765},
+				pos: position{line: 371, col: 11, offset: 8761},
 				run: (*parser).callonLiteral1,
 				expr: &choiceExpr{
-					pos: position{line: 338, col: 12, offset: 7766},
+					pos: position{line: 371, col: 12, offset: 8762},
 					alternatives: []interface{}{
 						&seqExpr{
-							pos: position{line: 338, col: 13, offset: 7767},
+							pos: position{line: 371, col: 13, offset: 8763},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 338, col: 13, offset: 7767},
+									pos:        position{line: 371, col: 13, offset: 8763},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 338, col: 17, offset: 7771},
+									pos: position{line: 371, col: 17, offset: 8767},
 									expr: &choiceExpr{
-										pos: position{line: 338, col: 18, offset: 7772},
+										pos: position{line: 371, col: 18, offset: 8768},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 338, col: 18, offset: 7772},
+												pos:        position{line: 371, col: 18, offset: 8768},
 												val:        "\\\"",
 												ignoreCase: false,
 											},
 											&charClassMatcher{
-												pos:        position{line: 338, col: 25, offset: 7779},
+												pos:        position{line: 371, col: 25, offset: 8775},
 												val:        "[^\"]",
 												chars:      []rune{'"'},
 												ignoreCase: false,
@@ -1739,32 +1951,32 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 338, col: 32, offset: 7786},
+									pos:        position{line: 371, col: 32, offset: 8782},
 									val:        "\"",
 									ignoreCase: false,
 								},
 							},
 						},
 						&seqExpr{
-							pos: position{line: 338, col: 40, offset: 7794},
+							pos: position{line: 371, col: 40, offset: 8790},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 338, col: 40, offset: 7794},
+									pos:        position{line: 371, col: 40, offset: 8790},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 338, col: 45, offset: 7799},
+									pos: position{line: 371, col: 45, offset: 8795},
 									expr: &choiceExpr{
-										pos: position{line: 338, col: 46, offset: 7800},
+										pos: position{line: 371, col: 46, offset: 8796},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 338, col: 46, offset: 7800},
+												pos:        position{line: 371, col: 46, offset: 8796},
 												val:        "\\'",
 												ignoreCase: false,
 											},
 											&charClassMatcher{
-												pos:        position{line: 338, col: 53, offset: 7807},
+												pos:        position{line: 371, col: 53, offset: 8803},
 												val:        "[^']",
 												chars:      []rune{'\''},
 												ignoreCase: false,
@@ -1774,7 +1986,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 338, col: 60, offset: 7814},
+									pos:        position{line: 371, col: 60, offset: 8810},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -1786,24 +1998,24 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 345, col: 1, offset: 8015},
+			pos:  position{line: 378, col: 1, offset: 9011},
 			expr: &actionExpr{
-				pos: position{line: 345, col: 14, offset: 8030},
+				pos: position{line: 378, col: 14, offset: 9026},
 				run: (*parser).callonIdentifier1,
 				expr: &seqExpr{
-					pos: position{line: 345, col: 14, offset: 8030},
+					pos: position{line: 378, col: 14, offset: 9026},
 					exprs: []interface{}{
 						&oneOrMoreExpr{
-							pos: position{line: 345, col: 14, offset: 8030},
+							pos: position{line: 378, col: 14, offset: 9026},
 							expr: &choiceExpr{
-								pos: position{line: 345, col: 15, offset: 8031},
+								pos: position{line: 378, col: 15, offset: 9027},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 345, col: 15, offset: 8031},
+										pos:  position{line: 378, col: 15, offset: 9027},
 										name: "Letter",
 									},
 									&litMatcher{
-										pos:        position{line: 345, col: 24, offset: 8040},
+										pos:        position{line: 378, col: 24, offset: 9036},
 										val:        "_",
 										ignoreCase: false,
 									},
@@ -1811,20 +2023,20 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 345, col: 30, offset: 8046},
+							pos: position{line: 378, col: 30, offset: 9042},
 							expr: &choiceExpr{
-								pos: position{line: 345, col: 31, offset: 8047},
+								pos: position{line: 378, col: 31, offset: 9043},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 345, col: 31, offset: 8047},
+										pos:  position{line: 378, col: 31, offset: 9043},
 										name: "Letter",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 345, col: 40, offset: 8056},
+										pos:  position{line: 378, col: 40, offset: 9052},
 										name: "Digit",
 									},
 									&charClassMatcher{
-										pos:        position{line: 345, col: 48, offset: 8064},
+										pos:        position{line: 378, col: 48, offset: 9060},
 										val:        "[._]",
 										chars:      []rune{'.', '_'},
 										ignoreCase: false,
@@ -1839,9 +2051,9 @@ var g = &grammar{
 		},
 		{
 			name: "ListSeparator",
-			pos:  position{line: 349, col: 1, offset: 8116},
+			pos:  position{line: 382, col: 1, offset: 9112},
 			expr: &charClassMatcher{
-				pos:        position{line: 349, col: 17, offset: 8134},
+				pos:        position{line: 382, col: 17, offset: 9130},
 				val:        "[,;]",
 				chars:      []rune{',', ';'},
 				ignoreCase: false,
@@ -1850,9 +2062,9 @@ var g = &grammar{
 		},
 		{
 			name: "Letter",
-			pos:  position{line: 350, col: 1, offset: 8139},
+			pos:  position{line: 383, col: 1, offset: 9135},
 			expr: &charClassMatcher{
-				pos:        position{line: 350, col: 10, offset: 8150},
+				pos:        position{line: 383, col: 10, offset: 9146},
 				val:        "[A-Za-z]",
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
 				ignoreCase: false,
@@ -1861,9 +2073,9 @@ var g = &grammar{
 		},
 		{
 			name: "Digit",
-			pos:  position{line: 351, col: 1, offset: 8159},
+			pos:  position{line: 384, col: 1, offset: 9155},
 			expr: &charClassMatcher{
-				pos:        position{line: 351, col: 9, offset: 8169},
+				pos:        position{line: 384, col: 9, offset: 9165},
 				val:        "[0-9]",
 				ranges:     []rune{'0', '9'},
 				ignoreCase: false,
@@ -1872,23 +2084,23 @@ var g = &grammar{
 		},
 		{
 			name: "SourceChar",
-			pos:  position{line: 355, col: 1, offset: 8180},
+			pos:  position{line: 388, col: 1, offset: 9176},
 			expr: &anyMatcher{
-				line: 355, col: 14, offset: 8195,
+				line: 388, col: 14, offset: 9191,
 			},
 		},
 		{
 			name: "Comment",
-			pos:  position{line: 356, col: 1, offset: 8197},
+			pos:  position{line: 389, col: 1, offset: 9193},
 			expr: &choiceExpr{
-				pos: position{line: 356, col: 11, offset: 8209},
+				pos: position{line: 389, col: 11, offset: 9205},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 356, col: 11, offset: 8209},
+						pos:  position{line: 389, col: 11, offset: 9205},
 						name: "MultiLineComment",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 356, col: 30, offset: 8228},
+						pos:  position{line: 389, col: 30, offset: 9224},
 						name: "SingleLineComment",
 					},
 				},
@@ -1896,37 +2108,37 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 357, col: 1, offset: 8246},
+			pos:  position{line: 390, col: 1, offset: 9242},
 			expr: &seqExpr{
-				pos: position{line: 357, col: 20, offset: 8267},
+				pos: position{line: 390, col: 20, offset: 9263},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 357, col: 20, offset: 8267},
+						pos:        position{line: 390, col: 20, offset: 9263},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 357, col: 25, offset: 8272},
+						pos: position{line: 390, col: 25, offset: 9268},
 						expr: &seqExpr{
-							pos: position{line: 357, col: 27, offset: 8274},
+							pos: position{line: 390, col: 27, offset: 9270},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 357, col: 27, offset: 8274},
+									pos: position{line: 390, col: 27, offset: 9270},
 									expr: &litMatcher{
-										pos:        position{line: 357, col: 28, offset: 8275},
+										pos:        position{line: 390, col: 28, offset: 9271},
 										val:        "*/",
 										ignoreCase: false,
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 357, col: 33, offset: 8280},
+									pos:  position{line: 390, col: 33, offset: 9276},
 									name: "SourceChar",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 357, col: 47, offset: 8294},
+						pos:        position{line: 390, col: 47, offset: 9290},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -1935,46 +2147,46 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineCommentNoLineTerminator",
-			pos:  position{line: 358, col: 1, offset: 8299},
+			pos:  position{line: 391, col: 1, offset: 9295},
 			expr: &seqExpr{
-				pos: position{line: 358, col: 36, offset: 8336},
+				pos: position{line: 391, col: 36, offset: 9332},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 358, col: 36, offset: 8336},
+						pos:        position{line: 391, col: 36, offset: 9332},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 358, col: 41, offset: 8341},
+						pos: position{line: 391, col: 41, offset: 9337},
 						expr: &seqExpr{
-							pos: position{line: 358, col: 43, offset: 8343},
+							pos: position{line: 391, col: 43, offset: 9339},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 358, col: 43, offset: 8343},
+									pos: position{line: 391, col: 43, offset: 9339},
 									expr: &choiceExpr{
-										pos: position{line: 358, col: 46, offset: 8346},
+										pos: position{line: 391, col: 46, offset: 9342},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 358, col: 46, offset: 8346},
+												pos:        position{line: 391, col: 46, offset: 9342},
 												val:        "*/",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 358, col: 53, offset: 8353},
+												pos:  position{line: 391, col: 53, offset: 9349},
 												name: "EOL",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 358, col: 59, offset: 8359},
+									pos:  position{line: 391, col: 59, offset: 9355},
 									name: "SourceChar",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 358, col: 73, offset: 8373},
+						pos:        position{line: 391, col: 73, offset: 9369},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -1983,32 +2195,32 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 359, col: 1, offset: 8378},
+			pos:  position{line: 392, col: 1, offset: 9374},
 			expr: &choiceExpr{
-				pos: position{line: 359, col: 21, offset: 8400},
+				pos: position{line: 392, col: 21, offset: 9396},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 359, col: 22, offset: 8401},
+						pos: position{line: 392, col: 22, offset: 9397},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 359, col: 22, offset: 8401},
+								pos:        position{line: 392, col: 22, offset: 9397},
 								val:        "//",
 								ignoreCase: false,
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 359, col: 27, offset: 8406},
+								pos: position{line: 392, col: 27, offset: 9402},
 								expr: &seqExpr{
-									pos: position{line: 359, col: 29, offset: 8408},
+									pos: position{line: 392, col: 29, offset: 9404},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 359, col: 29, offset: 8408},
+											pos: position{line: 392, col: 29, offset: 9404},
 											expr: &ruleRefExpr{
-												pos:  position{line: 359, col: 30, offset: 8409},
+												pos:  position{line: 392, col: 30, offset: 9405},
 												name: "EOL",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 359, col: 34, offset: 8413},
+											pos:  position{line: 392, col: 34, offset: 9409},
 											name: "SourceChar",
 										},
 									},
@@ -2017,27 +2229,27 @@ var g = &grammar{
 						},
 					},
 					&seqExpr{
-						pos: position{line: 359, col: 52, offset: 8431},
+						pos: position{line: 392, col: 52, offset: 9427},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 359, col: 52, offset: 8431},
+								pos:        position{line: 392, col: 52, offset: 9427},
 								val:        "#",
 								ignoreCase: false,
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 359, col: 56, offset: 8435},
+								pos: position{line: 392, col: 56, offset: 9431},
 								expr: &seqExpr{
-									pos: position{line: 359, col: 58, offset: 8437},
+									pos: position{line: 392, col: 58, offset: 9433},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 359, col: 58, offset: 8437},
+											pos: position{line: 392, col: 58, offset: 9433},
 											expr: &ruleRefExpr{
-												pos:  position{line: 359, col: 59, offset: 8438},
+												pos:  position{line: 392, col: 59, offset: 9434},
 												name: "EOL",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 359, col: 63, offset: 8442},
+											pos:  position{line: 392, col: 63, offset: 9438},
 											name: "SourceChar",
 										},
 									},
@@ -2050,22 +2262,22 @@ var g = &grammar{
 		},
 		{
 			name: "__",
-			pos:  position{line: 361, col: 1, offset: 8458},
+			pos:  position{line: 394, col: 1, offset: 9454},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 361, col: 6, offset: 8465},
+				pos: position{line: 394, col: 6, offset: 9461},
 				expr: &choiceExpr{
-					pos: position{line: 361, col: 8, offset: 8467},
+					pos: position{line: 394, col: 8, offset: 9463},
 					alternatives: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 361, col: 8, offset: 8467},
+							pos:  position{line: 394, col: 8, offset: 9463},
 							name: "Whitespace",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 361, col: 21, offset: 8480},
+							pos:  position{line: 394, col: 21, offset: 9476},
 							name: "EOL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 361, col: 27, offset: 8486},
+							pos:  position{line: 394, col: 27, offset: 9482},
 							name: "Comment",
 						},
 					},
@@ -2074,18 +2286,18 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 362, col: 1, offset: 8497},
+			pos:  position{line: 395, col: 1, offset: 9493},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 362, col: 5, offset: 8503},
+				pos: position{line: 395, col: 5, offset: 9499},
 				expr: &choiceExpr{
-					pos: position{line: 362, col: 7, offset: 8505},
+					pos: position{line: 395, col: 7, offset: 9501},
 					alternatives: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 362, col: 7, offset: 8505},
+							pos:  position{line: 395, col: 7, offset: 9501},
 							name: "Whitespace",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 362, col: 20, offset: 8518},
+							pos:  position{line: 395, col: 20, offset: 9514},
 							name: "MultiLineCommentNoLineTerminator",
 						},
 					},
@@ -2094,20 +2306,20 @@ var g = &grammar{
 		},
 		{
 			name: "WS",
-			pos:  position{line: 363, col: 1, offset: 8554},
+			pos:  position{line: 396, col: 1, offset: 9550},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 363, col: 6, offset: 8561},
+				pos: position{line: 396, col: 6, offset: 9557},
 				expr: &ruleRefExpr{
-					pos:  position{line: 363, col: 6, offset: 8561},
+					pos:  position{line: 396, col: 6, offset: 9557},
 					name: "Whitespace",
 				},
 			},
 		},
 		{
 			name: "Whitespace",
-			pos:  position{line: 365, col: 1, offset: 8574},
+			pos:  position{line: 398, col: 1, offset: 9570},
 			expr: &charClassMatcher{
-				pos:        position{line: 365, col: 14, offset: 8589},
+				pos:        position{line: 398, col: 14, offset: 9585},
 				val:        "[ \\t\\r]",
 				chars:      []rune{' ', '\t', '\r'},
 				ignoreCase: false,
@@ -2116,62 +2328,62 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 366, col: 1, offset: 8597},
+			pos:  position{line: 399, col: 1, offset: 9593},
 			expr: &litMatcher{
-				pos:        position{line: 366, col: 7, offset: 8605},
+				pos:        position{line: 399, col: 7, offset: 9601},
 				val:        "\n",
 				ignoreCase: false,
 			},
 		},
 		{
 			name: "EOS",
-			pos:  position{line: 367, col: 1, offset: 8610},
+			pos:  position{line: 400, col: 1, offset: 9606},
 			expr: &choiceExpr{
-				pos: position{line: 367, col: 7, offset: 8618},
+				pos: position{line: 400, col: 7, offset: 9614},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 367, col: 7, offset: 8618},
+						pos: position{line: 400, col: 7, offset: 9614},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 367, col: 7, offset: 8618},
+								pos:  position{line: 400, col: 7, offset: 9614},
 								name: "__",
 							},
 							&litMatcher{
-								pos:        position{line: 367, col: 10, offset: 8621},
+								pos:        position{line: 400, col: 10, offset: 9617},
 								val:        ";",
 								ignoreCase: false,
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 367, col: 16, offset: 8627},
+						pos: position{line: 400, col: 16, offset: 9623},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 367, col: 16, offset: 8627},
+								pos:  position{line: 400, col: 16, offset: 9623},
 								name: "_",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 367, col: 18, offset: 8629},
+								pos: position{line: 400, col: 18, offset: 9625},
 								expr: &ruleRefExpr{
-									pos:  position{line: 367, col: 18, offset: 8629},
+									pos:  position{line: 400, col: 18, offset: 9625},
 									name: "SingleLineComment",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 367, col: 37, offset: 8648},
+								pos:  position{line: 400, col: 37, offset: 9644},
 								name: "EOL",
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 367, col: 43, offset: 8654},
+						pos: position{line: 400, col: 43, offset: 9650},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 367, col: 43, offset: 8654},
+								pos:  position{line: 400, col: 43, offset: 9650},
 								name: "__",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 367, col: 46, offset: 8657},
+								pos:  position{line: 400, col: 46, offset: 9653},
 								name: "EOF",
 							},
 						},
@@ -2181,11 +2393,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 369, col: 1, offset: 8662},
+			pos:  position{line: 402, col: 1, offset: 9658},
 			expr: &notExpr{
-				pos: position{line: 369, col: 7, offset: 8670},
+				pos: position{line: 402, col: 7, offset: 9666},
 				expr: &anyMatcher{
-					line: 369, col: 8, offset: 8671,
+					line: 402, col: 8, offset: 9667,
 				},
 			},
 		},
@@ -2196,7 +2408,7 @@ func (c *current) onGrammar1(statements interface{}) (interface{}, error) {
 	thrift := &Thrift{
 		Includes:   make(map[string]string),
 		Namespaces: make(map[string]string),
-		Typedefs:   make(map[string]*Type),
+		Typedefs:   make(map[string]*Typedef),
 		Constants:  make(map[string]*Constant),
 		Enums:      make(map[string]*Enum),
 		Structs:    make(map[string]*Struct),
@@ -2213,8 +2425,8 @@ func (c *current) onGrammar1(statements interface{}) (interface{}, error) {
 			thrift.Constants[v.Name] = v
 		case *Enum:
 			thrift.Enums[v.Name] = v
-		case *typeDef:
-			thrift.Typedefs[v.name] = v.typ
+		case *Typedef:
+			thrift.Typedefs[v.Alias] = v
 		case *Struct:
 			thrift.Structs[v.Name] = v
 		case exception:
@@ -2335,17 +2547,19 @@ func (p *parser) callonEnumValue1() (interface{}, error) {
 	return p.cur.onEnumValue1(stack["name"], stack["value"])
 }
 
-func (c *current) onTypeDef1(typ, name interface{}) (interface{}, error) {
-	return &typeDef{
-		name: string(name.(Identifier)),
-		typ:  typ.(*Type),
+func (c *current) onTypeDef1(typ, name, annotations interface{}) (interface{}, error) {
+	return &Typedef{
+		Type: typ.(*Type),
+
+		Alias:       string(name.(Identifier)),
+		Annotations: toAnnotations(annotations),
 	}, nil
 }
 
 func (p *parser) callonTypeDef1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onTypeDef1(stack["typ"], stack["name"])
+	return p.cur.onTypeDef1(stack["typ"], stack["name"], stack["annotations"])
 }
 
 func (c *current) onStruct1(st interface{}) (interface{}, error) {
@@ -2547,14 +2761,27 @@ func (p *parser) callonDefinitionType1() (interface{}, error) {
 	return p.cur.onDefinitionType1(stack["typ"])
 }
 
-func (c *current) onBaseType1() (interface{}, error) {
-	return &Type{Name: string(c.text)}, nil
+func (c *current) onBaseType1(name, annotations interface{}) (interface{}, error) {
+	return &Type{
+		Name:        name.(string),
+		Annotations: toAnnotations(annotations),
+	}, nil
 }
 
 func (p *parser) callonBaseType1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onBaseType1()
+	return p.cur.onBaseType1(stack["name"], stack["annotations"])
+}
+
+func (c *current) onBaseTypeName1() (interface{}, error) {
+	return string(c.text), nil
+}
+
+func (p *parser) callonBaseTypeName1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onBaseTypeName1()
 }
 
 func (c *current) onContainerType1(typ interface{}) (interface{}, error) {
@@ -2567,44 +2794,47 @@ func (p *parser) callonContainerType1() (interface{}, error) {
 	return p.cur.onContainerType1(stack["typ"])
 }
 
-func (c *current) onMapType1(key, value interface{}) (interface{}, error) {
+func (c *current) onMapType1(key, value, annotations interface{}) (interface{}, error) {
 	return &Type{
-		Name:      "map",
-		KeyType:   key.(*Type),
-		ValueType: value.(*Type),
+		Name:        "map",
+		KeyType:     key.(*Type),
+		ValueType:   value.(*Type),
+		Annotations: toAnnotations(annotations),
 	}, nil
 }
 
 func (p *parser) callonMapType1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onMapType1(stack["key"], stack["value"])
+	return p.cur.onMapType1(stack["key"], stack["value"], stack["annotations"])
 }
 
-func (c *current) onSetType1(typ interface{}) (interface{}, error) {
+func (c *current) onSetType1(typ, annotations interface{}) (interface{}, error) {
 	return &Type{
-		Name:      "set",
-		ValueType: typ.(*Type),
+		Name:        "set",
+		ValueType:   typ.(*Type),
+		Annotations: toAnnotations(annotations),
 	}, nil
 }
 
 func (p *parser) callonSetType1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onSetType1(stack["typ"])
+	return p.cur.onSetType1(stack["typ"], stack["annotations"])
 }
 
-func (c *current) onListType1(typ interface{}) (interface{}, error) {
+func (c *current) onListType1(typ, annotations interface{}) (interface{}, error) {
 	return &Type{
-		Name:      "list",
-		ValueType: typ.(*Type),
+		Name:        "list",
+		ValueType:   typ.(*Type),
+		Annotations: toAnnotations(annotations),
 	}, nil
 }
 
 func (p *parser) callonListType1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onListType1(stack["typ"])
+	return p.cur.onListType1(stack["typ"], stack["annotations"])
 }
 
 func (c *current) onCppType1(cppType interface{}) (interface{}, error) {
@@ -2615,6 +2845,47 @@ func (p *parser) callonCppType1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
 	return p.cur.onCppType1(stack["cppType"])
+}
+
+func (c *current) onTypeAnnotations1(annotations interface{}) (interface{}, error) {
+	var anns []*Annotation
+	for _, ann := range annotations.([]interface{}) {
+		anns = append(anns, ann.(*Annotation))
+	}
+	return anns, nil
+}
+
+func (p *parser) callonTypeAnnotations1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onTypeAnnotations1(stack["annotations"])
+}
+
+func (c *current) onTypeAnnotation8(value interface{}) (interface{}, error) {
+	return value, nil
+}
+
+func (p *parser) callonTypeAnnotation8() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onTypeAnnotation8(stack["value"])
+}
+
+func (c *current) onTypeAnnotation1(name, value interface{}) (interface{}, error) {
+	var optValue string
+	if value != nil {
+		optValue = value.(string)
+	}
+	return &Annotation{
+		Name:  string(name.(Identifier)),
+		Value: optValue,
+	}, nil
+}
+
+func (p *parser) callonTypeAnnotation1() (interface{}, error) {
+	stack := p.vstack[len(p.vstack)-1]
+	_ = stack
+	return p.cur.onTypeAnnotation1(stack["name"], stack["value"])
 }
 
 func (c *current) onIntConstant1() (interface{}, error) {

--- a/parser/grammar.peg.go
+++ b/parser/grammar.peg.go
@@ -387,6 +387,21 @@ var g = &grammar{
 						},
 						&ruleRefExpr{
 							pos:  position{line: 125, col: 70, offset: 2761},
+							name: "__",
+						},
+						&labeledExpr{
+							pos:   position{line: 125, col: 73, offset: 2764},
+							label: "annotations",
+							expr: &zeroOrOneExpr{
+								pos: position{line: 125, col: 85, offset: 2776},
+								expr: &ruleRefExpr{
+									pos:  position{line: 125, col: 85, offset: 2776},
+									name: "TypeAnnotations",
+								},
+							},
+						},
+						&ruleRefExpr{
+							pos:  position{line: 125, col: 102, offset: 2793},
 							name: "EOS",
 						},
 					},
@@ -395,61 +410,69 @@ var g = &grammar{
 		},
 		{
 			name: "EnumValue",
-			pos:  position{line: 148, col: 1, offset: 3277},
+			pos:  position{line: 149, col: 1, offset: 3352},
 			expr: &actionExpr{
-				pos: position{line: 148, col: 13, offset: 3291},
+				pos: position{line: 149, col: 13, offset: 3366},
 				run: (*parser).callonEnumValue1,
 				expr: &seqExpr{
-					pos: position{line: 148, col: 13, offset: 3291},
+					pos: position{line: 149, col: 13, offset: 3366},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 148, col: 13, offset: 3291},
+							pos:   position{line: 149, col: 13, offset: 3366},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 148, col: 18, offset: 3296},
+								pos:  position{line: 149, col: 18, offset: 3371},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 148, col: 29, offset: 3307},
+							pos:  position{line: 149, col: 29, offset: 3382},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 148, col: 31, offset: 3309},
+							pos:   position{line: 149, col: 31, offset: 3384},
 							label: "value",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 148, col: 37, offset: 3315},
+								pos: position{line: 149, col: 37, offset: 3390},
 								expr: &seqExpr{
-									pos: position{line: 148, col: 38, offset: 3316},
+									pos: position{line: 149, col: 38, offset: 3391},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 148, col: 38, offset: 3316},
+											pos:        position{line: 149, col: 38, offset: 3391},
 											val:        "=",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 148, col: 42, offset: 3320},
+											pos:  position{line: 149, col: 42, offset: 3395},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 148, col: 44, offset: 3322},
+											pos:  position{line: 149, col: 44, offset: 3397},
 											name: "IntConstant",
 										},
 									},
 								},
 							},
 						},
-						&zeroOrOneExpr{
-							pos: position{line: 148, col: 58, offset: 3336},
-							expr: &ruleRefExpr{
-								pos:  position{line: 148, col: 58, offset: 3336},
-								name: "TypeAnnotations",
+						&ruleRefExpr{
+							pos:  position{line: 149, col: 58, offset: 3411},
+							name: "__",
+						},
+						&labeledExpr{
+							pos:   position{line: 149, col: 61, offset: 3414},
+							label: "annotations",
+							expr: &zeroOrOneExpr{
+								pos: position{line: 149, col: 73, offset: 3426},
+								expr: &ruleRefExpr{
+									pos:  position{line: 149, col: 73, offset: 3426},
+									name: "TypeAnnotations",
+								},
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 148, col: 75, offset: 3353},
+							pos: position{line: 149, col: 90, offset: 3443},
 							expr: &ruleRefExpr{
-								pos:  position{line: 148, col: 75, offset: 3353},
+								pos:  position{line: 149, col: 90, offset: 3443},
 								name: "ListSeparator",
 							},
 						},
@@ -459,59 +482,59 @@ var g = &grammar{
 		},
 		{
 			name: "TypeDef",
-			pos:  position{line: 159, col: 1, offset: 3532},
+			pos:  position{line: 161, col: 1, offset: 3665},
 			expr: &actionExpr{
-				pos: position{line: 159, col: 11, offset: 3544},
+				pos: position{line: 161, col: 11, offset: 3677},
 				run: (*parser).callonTypeDef1,
 				expr: &seqExpr{
-					pos: position{line: 159, col: 11, offset: 3544},
+					pos: position{line: 161, col: 11, offset: 3677},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 159, col: 11, offset: 3544},
+							pos:        position{line: 161, col: 11, offset: 3677},
 							val:        "typedef",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 159, col: 21, offset: 3554},
+							pos:  position{line: 161, col: 21, offset: 3687},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 159, col: 23, offset: 3556},
+							pos:   position{line: 161, col: 23, offset: 3689},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 159, col: 27, offset: 3560},
+								pos:  position{line: 161, col: 27, offset: 3693},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 159, col: 37, offset: 3570},
+							pos:  position{line: 161, col: 37, offset: 3703},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 159, col: 39, offset: 3572},
+							pos:   position{line: 161, col: 39, offset: 3705},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 159, col: 44, offset: 3577},
+								pos:  position{line: 161, col: 44, offset: 3710},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 159, col: 55, offset: 3588},
+							pos:  position{line: 161, col: 55, offset: 3721},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 159, col: 57, offset: 3590},
+							pos:   position{line: 161, col: 57, offset: 3723},
 							label: "annotations",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 159, col: 69, offset: 3602},
+								pos: position{line: 161, col: 69, offset: 3735},
 								expr: &ruleRefExpr{
-									pos:  position{line: 159, col: 69, offset: 3602},
+									pos:  position{line: 161, col: 69, offset: 3735},
 									name: "TypeAnnotations",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 159, col: 86, offset: 3619},
+							pos:  position{line: 161, col: 86, offset: 3752},
 							name: "EOS",
 						},
 					},
@@ -520,27 +543,27 @@ var g = &grammar{
 		},
 		{
 			name: "Struct",
-			pos:  position{line: 168, col: 1, offset: 3755},
+			pos:  position{line: 170, col: 1, offset: 3888},
 			expr: &actionExpr{
-				pos: position{line: 168, col: 10, offset: 3766},
+				pos: position{line: 170, col: 10, offset: 3899},
 				run: (*parser).callonStruct1,
 				expr: &seqExpr{
-					pos: position{line: 168, col: 10, offset: 3766},
+					pos: position{line: 170, col: 10, offset: 3899},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 168, col: 10, offset: 3766},
+							pos:        position{line: 170, col: 10, offset: 3899},
 							val:        "struct",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 168, col: 19, offset: 3775},
+							pos:  position{line: 170, col: 19, offset: 3908},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 168, col: 21, offset: 3777},
+							pos:   position{line: 170, col: 21, offset: 3910},
 							label: "st",
 							expr: &ruleRefExpr{
-								pos:  position{line: 168, col: 24, offset: 3780},
+								pos:  position{line: 170, col: 24, offset: 3913},
 								name: "StructLike",
 							},
 						},
@@ -550,27 +573,27 @@ var g = &grammar{
 		},
 		{
 			name: "Exception",
-			pos:  position{line: 169, col: 1, offset: 3820},
+			pos:  position{line: 171, col: 1, offset: 3953},
 			expr: &actionExpr{
-				pos: position{line: 169, col: 13, offset: 3834},
+				pos: position{line: 171, col: 13, offset: 3967},
 				run: (*parser).callonException1,
 				expr: &seqExpr{
-					pos: position{line: 169, col: 13, offset: 3834},
+					pos: position{line: 171, col: 13, offset: 3967},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 169, col: 13, offset: 3834},
+							pos:        position{line: 171, col: 13, offset: 3967},
 							val:        "exception",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 169, col: 25, offset: 3846},
+							pos:  position{line: 171, col: 25, offset: 3979},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 169, col: 27, offset: 3848},
+							pos:   position{line: 171, col: 27, offset: 3981},
 							label: "st",
 							expr: &ruleRefExpr{
-								pos:  position{line: 169, col: 30, offset: 3851},
+								pos:  position{line: 171, col: 30, offset: 3984},
 								name: "StructLike",
 							},
 						},
@@ -580,27 +603,27 @@ var g = &grammar{
 		},
 		{
 			name: "Union",
-			pos:  position{line: 170, col: 1, offset: 3902},
+			pos:  position{line: 172, col: 1, offset: 4035},
 			expr: &actionExpr{
-				pos: position{line: 170, col: 9, offset: 3912},
+				pos: position{line: 172, col: 9, offset: 4045},
 				run: (*parser).callonUnion1,
 				expr: &seqExpr{
-					pos: position{line: 170, col: 9, offset: 3912},
+					pos: position{line: 172, col: 9, offset: 4045},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 170, col: 9, offset: 3912},
+							pos:        position{line: 172, col: 9, offset: 4045},
 							val:        "union",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 170, col: 17, offset: 3920},
+							pos:  position{line: 172, col: 17, offset: 4053},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 170, col: 19, offset: 3922},
+							pos:   position{line: 172, col: 19, offset: 4055},
 							label: "st",
 							expr: &ruleRefExpr{
-								pos:  position{line: 170, col: 22, offset: 3925},
+								pos:  position{line: 172, col: 22, offset: 4058},
 								name: "StructLike",
 							},
 						},
@@ -610,49 +633,49 @@ var g = &grammar{
 		},
 		{
 			name: "StructLike",
-			pos:  position{line: 171, col: 1, offset: 3972},
+			pos:  position{line: 173, col: 1, offset: 4105},
 			expr: &actionExpr{
-				pos: position{line: 171, col: 14, offset: 3987},
+				pos: position{line: 173, col: 14, offset: 4120},
 				run: (*parser).callonStructLike1,
 				expr: &seqExpr{
-					pos: position{line: 171, col: 14, offset: 3987},
+					pos: position{line: 173, col: 14, offset: 4120},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 171, col: 14, offset: 3987},
+							pos:   position{line: 173, col: 14, offset: 4120},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 171, col: 19, offset: 3992},
+								pos:  position{line: 173, col: 19, offset: 4125},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 171, col: 30, offset: 4003},
+							pos:  position{line: 173, col: 30, offset: 4136},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 171, col: 33, offset: 4006},
+							pos:        position{line: 173, col: 33, offset: 4139},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 171, col: 37, offset: 4010},
+							pos:  position{line: 173, col: 37, offset: 4143},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 171, col: 40, offset: 4013},
+							pos:   position{line: 173, col: 40, offset: 4146},
 							label: "fields",
 							expr: &ruleRefExpr{
-								pos:  position{line: 171, col: 47, offset: 4020},
+								pos:  position{line: 173, col: 47, offset: 4153},
 								name: "FieldList",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 171, col: 57, offset: 4030},
+							pos:        position{line: 173, col: 57, offset: 4163},
 							val:        "}",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 171, col: 61, offset: 4034},
+							pos:  position{line: 173, col: 61, offset: 4167},
 							name: "EOS",
 						},
 					},
@@ -661,24 +684,24 @@ var g = &grammar{
 		},
 		{
 			name: "FieldList",
-			pos:  position{line: 181, col: 1, offset: 4168},
+			pos:  position{line: 183, col: 1, offset: 4301},
 			expr: &actionExpr{
-				pos: position{line: 181, col: 13, offset: 4182},
+				pos: position{line: 183, col: 13, offset: 4315},
 				run: (*parser).callonFieldList1,
 				expr: &labeledExpr{
-					pos:   position{line: 181, col: 13, offset: 4182},
+					pos:   position{line: 183, col: 13, offset: 4315},
 					label: "fields",
 					expr: &zeroOrMoreExpr{
-						pos: position{line: 181, col: 20, offset: 4189},
+						pos: position{line: 183, col: 20, offset: 4322},
 						expr: &seqExpr{
-							pos: position{line: 181, col: 21, offset: 4190},
+							pos: position{line: 183, col: 21, offset: 4323},
 							exprs: []interface{}{
 								&ruleRefExpr{
-									pos:  position{line: 181, col: 21, offset: 4190},
+									pos:  position{line: 183, col: 21, offset: 4323},
 									name: "Field",
 								},
 								&ruleRefExpr{
-									pos:  position{line: 181, col: 27, offset: 4196},
+									pos:  position{line: 183, col: 27, offset: 4329},
 									name: "__",
 								},
 							},
@@ -689,92 +712,92 @@ var g = &grammar{
 		},
 		{
 			name: "Field",
-			pos:  position{line: 190, col: 1, offset: 4356},
+			pos:  position{line: 192, col: 1, offset: 4489},
 			expr: &actionExpr{
-				pos: position{line: 190, col: 9, offset: 4366},
+				pos: position{line: 192, col: 9, offset: 4499},
 				run: (*parser).callonField1,
 				expr: &seqExpr{
-					pos: position{line: 190, col: 9, offset: 4366},
+					pos: position{line: 192, col: 9, offset: 4499},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 190, col: 9, offset: 4366},
+							pos:   position{line: 192, col: 9, offset: 4499},
 							label: "id",
 							expr: &ruleRefExpr{
-								pos:  position{line: 190, col: 12, offset: 4369},
+								pos:  position{line: 192, col: 12, offset: 4502},
 								name: "IntConstant",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 190, col: 24, offset: 4381},
+							pos:  position{line: 192, col: 24, offset: 4514},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 190, col: 26, offset: 4383},
+							pos:        position{line: 192, col: 26, offset: 4516},
 							val:        ":",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 190, col: 30, offset: 4387},
+							pos:  position{line: 192, col: 30, offset: 4520},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 190, col: 32, offset: 4389},
+							pos:   position{line: 192, col: 32, offset: 4522},
 							label: "req",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 190, col: 36, offset: 4393},
+								pos: position{line: 192, col: 36, offset: 4526},
 								expr: &ruleRefExpr{
-									pos:  position{line: 190, col: 36, offset: 4393},
+									pos:  position{line: 192, col: 36, offset: 4526},
 									name: "FieldReq",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 190, col: 46, offset: 4403},
+							pos:  position{line: 192, col: 46, offset: 4536},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 190, col: 48, offset: 4405},
+							pos:   position{line: 192, col: 48, offset: 4538},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 190, col: 52, offset: 4409},
+								pos:  position{line: 192, col: 52, offset: 4542},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 190, col: 62, offset: 4419},
+							pos:  position{line: 192, col: 62, offset: 4552},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 190, col: 64, offset: 4421},
+							pos:   position{line: 192, col: 64, offset: 4554},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 190, col: 69, offset: 4426},
+								pos:  position{line: 192, col: 69, offset: 4559},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 190, col: 80, offset: 4437},
+							pos:  position{line: 192, col: 80, offset: 4570},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 190, col: 83, offset: 4440},
+							pos:   position{line: 192, col: 83, offset: 4573},
 							label: "def",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 190, col: 87, offset: 4444},
+								pos: position{line: 192, col: 87, offset: 4577},
 								expr: &seqExpr{
-									pos: position{line: 190, col: 88, offset: 4445},
+									pos: position{line: 192, col: 88, offset: 4578},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 190, col: 88, offset: 4445},
+											pos:        position{line: 192, col: 88, offset: 4578},
 											val:        "=",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 190, col: 92, offset: 4449},
+											pos:  position{line: 192, col: 92, offset: 4582},
 											name: "_",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 190, col: 94, offset: 4451},
+											pos:  position{line: 192, col: 94, offset: 4584},
 											name: "ConstValue",
 										},
 									},
@@ -782,9 +805,9 @@ var g = &grammar{
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 190, col: 107, offset: 4464},
+							pos: position{line: 192, col: 107, offset: 4597},
 							expr: &ruleRefExpr{
-								pos:  position{line: 190, col: 107, offset: 4464},
+								pos:  position{line: 192, col: 107, offset: 4597},
 								name: "ListSeparator",
 							},
 						},
@@ -794,20 +817,20 @@ var g = &grammar{
 		},
 		{
 			name: "FieldReq",
-			pos:  position{line: 205, col: 1, offset: 4724},
+			pos:  position{line: 207, col: 1, offset: 4857},
 			expr: &actionExpr{
-				pos: position{line: 205, col: 12, offset: 4737},
+				pos: position{line: 207, col: 12, offset: 4870},
 				run: (*parser).callonFieldReq1,
 				expr: &choiceExpr{
-					pos: position{line: 205, col: 13, offset: 4738},
+					pos: position{line: 207, col: 13, offset: 4871},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 205, col: 13, offset: 4738},
+							pos:        position{line: 207, col: 13, offset: 4871},
 							val:        "required",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 205, col: 26, offset: 4751},
+							pos:        position{line: 207, col: 26, offset: 4884},
 							val:        "optional",
 							ignoreCase: false,
 						},
@@ -817,57 +840,57 @@ var g = &grammar{
 		},
 		{
 			name: "Service",
-			pos:  position{line: 209, col: 1, offset: 4822},
+			pos:  position{line: 211, col: 1, offset: 4955},
 			expr: &actionExpr{
-				pos: position{line: 209, col: 11, offset: 4834},
+				pos: position{line: 211, col: 11, offset: 4967},
 				run: (*parser).callonService1,
 				expr: &seqExpr{
-					pos: position{line: 209, col: 11, offset: 4834},
+					pos: position{line: 211, col: 11, offset: 4967},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 209, col: 11, offset: 4834},
+							pos:        position{line: 211, col: 11, offset: 4967},
 							val:        "service",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 209, col: 21, offset: 4844},
+							pos:  position{line: 211, col: 21, offset: 4977},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 209, col: 23, offset: 4846},
+							pos:   position{line: 211, col: 23, offset: 4979},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 209, col: 28, offset: 4851},
+								pos:  position{line: 211, col: 28, offset: 4984},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 209, col: 39, offset: 4862},
+							pos:  position{line: 211, col: 39, offset: 4995},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 209, col: 41, offset: 4864},
+							pos:   position{line: 211, col: 41, offset: 4997},
 							label: "extends",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 209, col: 49, offset: 4872},
+								pos: position{line: 211, col: 49, offset: 5005},
 								expr: &seqExpr{
-									pos: position{line: 209, col: 50, offset: 4873},
+									pos: position{line: 211, col: 50, offset: 5006},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 209, col: 50, offset: 4873},
+											pos:        position{line: 211, col: 50, offset: 5006},
 											val:        "extends",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 209, col: 60, offset: 4883},
+											pos:  position{line: 211, col: 60, offset: 5016},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 209, col: 63, offset: 4886},
+											pos:  position{line: 211, col: 63, offset: 5019},
 											name: "Identifier",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 209, col: 74, offset: 4897},
+											pos:  position{line: 211, col: 74, offset: 5030},
 											name: "__",
 										},
 									},
@@ -875,32 +898,32 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 209, col: 79, offset: 4902},
+							pos:  position{line: 211, col: 79, offset: 5035},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 209, col: 82, offset: 4905},
+							pos:        position{line: 211, col: 82, offset: 5038},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 209, col: 86, offset: 4909},
+							pos:  position{line: 211, col: 86, offset: 5042},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 209, col: 89, offset: 4912},
+							pos:   position{line: 211, col: 89, offset: 5045},
 							label: "methods",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 209, col: 97, offset: 4920},
+								pos: position{line: 211, col: 97, offset: 5053},
 								expr: &seqExpr{
-									pos: position{line: 209, col: 98, offset: 4921},
+									pos: position{line: 211, col: 98, offset: 5054},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 209, col: 98, offset: 4921},
+											pos:  position{line: 211, col: 98, offset: 5054},
 											name: "Function",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 209, col: 107, offset: 4930},
+											pos:  position{line: 211, col: 107, offset: 5063},
 											name: "__",
 										},
 									},
@@ -908,21 +931,21 @@ var g = &grammar{
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 209, col: 113, offset: 4936},
+							pos: position{line: 211, col: 113, offset: 5069},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 209, col: 113, offset: 4936},
+									pos:        position{line: 211, col: 113, offset: 5069},
 									val:        "}",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 209, col: 119, offset: 4942},
+									pos:  position{line: 211, col: 119, offset: 5075},
 									name: "EndOfServiceError",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 209, col: 138, offset: 4961},
+							pos:  position{line: 211, col: 138, offset: 5094},
 							name: "EOS",
 						},
 					},
@@ -931,39 +954,39 @@ var g = &grammar{
 		},
 		{
 			name: "EndOfServiceError",
-			pos:  position{line: 224, col: 1, offset: 5302},
+			pos:  position{line: 226, col: 1, offset: 5435},
 			expr: &actionExpr{
-				pos: position{line: 224, col: 21, offset: 5324},
+				pos: position{line: 226, col: 21, offset: 5457},
 				run: (*parser).callonEndOfServiceError1,
 				expr: &anyMatcher{
-					line: 224, col: 21, offset: 5324,
+					line: 226, col: 21, offset: 5457,
 				},
 			},
 		},
 		{
 			name: "Function",
-			pos:  position{line: 228, col: 1, offset: 5390},
+			pos:  position{line: 230, col: 1, offset: 5523},
 			expr: &actionExpr{
-				pos: position{line: 228, col: 12, offset: 5403},
+				pos: position{line: 230, col: 12, offset: 5536},
 				run: (*parser).callonFunction1,
 				expr: &seqExpr{
-					pos: position{line: 228, col: 12, offset: 5403},
+					pos: position{line: 230, col: 12, offset: 5536},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 228, col: 12, offset: 5403},
+							pos:   position{line: 230, col: 12, offset: 5536},
 							label: "oneway",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 228, col: 19, offset: 5410},
+								pos: position{line: 230, col: 19, offset: 5543},
 								expr: &seqExpr{
-									pos: position{line: 228, col: 20, offset: 5411},
+									pos: position{line: 230, col: 20, offset: 5544},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 228, col: 20, offset: 5411},
+											pos:        position{line: 230, col: 20, offset: 5544},
 											val:        "oneway",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 228, col: 29, offset: 5420},
+											pos:  position{line: 230, col: 29, offset: 5553},
 											name: "__",
 										},
 									},
@@ -971,70 +994,70 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 228, col: 34, offset: 5425},
+							pos:   position{line: 230, col: 34, offset: 5558},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 228, col: 38, offset: 5429},
+								pos:  position{line: 230, col: 38, offset: 5562},
 								name: "FunctionType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 228, col: 51, offset: 5442},
+							pos:  position{line: 230, col: 51, offset: 5575},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 228, col: 54, offset: 5445},
+							pos:   position{line: 230, col: 54, offset: 5578},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 228, col: 59, offset: 5450},
+								pos:  position{line: 230, col: 59, offset: 5583},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 228, col: 70, offset: 5461},
+							pos:  position{line: 230, col: 70, offset: 5594},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 228, col: 72, offset: 5463},
+							pos:        position{line: 230, col: 72, offset: 5596},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 228, col: 76, offset: 5467},
+							pos:  position{line: 230, col: 76, offset: 5600},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 228, col: 79, offset: 5470},
+							pos:   position{line: 230, col: 79, offset: 5603},
 							label: "arguments",
 							expr: &ruleRefExpr{
-								pos:  position{line: 228, col: 89, offset: 5480},
+								pos:  position{line: 230, col: 89, offset: 5613},
 								name: "FieldList",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 228, col: 99, offset: 5490},
+							pos:        position{line: 230, col: 99, offset: 5623},
 							val:        ")",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 228, col: 103, offset: 5494},
+							pos:  position{line: 230, col: 103, offset: 5627},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 228, col: 106, offset: 5497},
+							pos:   position{line: 230, col: 106, offset: 5630},
 							label: "exceptions",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 228, col: 117, offset: 5508},
+								pos: position{line: 230, col: 117, offset: 5641},
 								expr: &ruleRefExpr{
-									pos:  position{line: 228, col: 117, offset: 5508},
+									pos:  position{line: 230, col: 117, offset: 5641},
 									name: "Throws",
 								},
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 228, col: 125, offset: 5516},
+							pos: position{line: 230, col: 125, offset: 5649},
 							expr: &ruleRefExpr{
-								pos:  position{line: 228, col: 125, offset: 5516},
+								pos:  position{line: 230, col: 125, offset: 5649},
 								name: "ListSeparator",
 							},
 						},
@@ -1044,23 +1067,23 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionType",
-			pos:  position{line: 251, col: 1, offset: 5897},
+			pos:  position{line: 253, col: 1, offset: 6030},
 			expr: &actionExpr{
-				pos: position{line: 251, col: 16, offset: 5914},
+				pos: position{line: 253, col: 16, offset: 6047},
 				run: (*parser).callonFunctionType1,
 				expr: &labeledExpr{
-					pos:   position{line: 251, col: 16, offset: 5914},
+					pos:   position{line: 253, col: 16, offset: 6047},
 					label: "typ",
 					expr: &choiceExpr{
-						pos: position{line: 251, col: 21, offset: 5919},
+						pos: position{line: 253, col: 21, offset: 6052},
 						alternatives: []interface{}{
 							&litMatcher{
-								pos:        position{line: 251, col: 21, offset: 5919},
+								pos:        position{line: 253, col: 21, offset: 6052},
 								val:        "void",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 251, col: 30, offset: 5928},
+								pos:  position{line: 253, col: 30, offset: 6061},
 								name: "FieldType",
 							},
 						},
@@ -1070,41 +1093,41 @@ var g = &grammar{
 		},
 		{
 			name: "Throws",
-			pos:  position{line: 258, col: 1, offset: 6035},
+			pos:  position{line: 260, col: 1, offset: 6168},
 			expr: &actionExpr{
-				pos: position{line: 258, col: 10, offset: 6046},
+				pos: position{line: 260, col: 10, offset: 6179},
 				run: (*parser).callonThrows1,
 				expr: &seqExpr{
-					pos: position{line: 258, col: 10, offset: 6046},
+					pos: position{line: 260, col: 10, offset: 6179},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 258, col: 10, offset: 6046},
+							pos:        position{line: 260, col: 10, offset: 6179},
 							val:        "throws",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 258, col: 19, offset: 6055},
+							pos:  position{line: 260, col: 19, offset: 6188},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 258, col: 22, offset: 6058},
+							pos:        position{line: 260, col: 22, offset: 6191},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 258, col: 26, offset: 6062},
+							pos:  position{line: 260, col: 26, offset: 6195},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 258, col: 29, offset: 6065},
+							pos:   position{line: 260, col: 29, offset: 6198},
 							label: "exceptions",
 							expr: &ruleRefExpr{
-								pos:  position{line: 258, col: 40, offset: 6076},
+								pos:  position{line: 260, col: 40, offset: 6209},
 								name: "FieldList",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 258, col: 50, offset: 6086},
+							pos:        position{line: 260, col: 50, offset: 6219},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -1114,26 +1137,26 @@ var g = &grammar{
 		},
 		{
 			name: "FieldType",
-			pos:  position{line: 262, col: 1, offset: 6119},
+			pos:  position{line: 264, col: 1, offset: 6252},
 			expr: &actionExpr{
-				pos: position{line: 262, col: 13, offset: 6133},
+				pos: position{line: 264, col: 13, offset: 6266},
 				run: (*parser).callonFieldType1,
 				expr: &labeledExpr{
-					pos:   position{line: 262, col: 13, offset: 6133},
+					pos:   position{line: 264, col: 13, offset: 6266},
 					label: "typ",
 					expr: &choiceExpr{
-						pos: position{line: 262, col: 18, offset: 6138},
+						pos: position{line: 264, col: 18, offset: 6271},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 262, col: 18, offset: 6138},
+								pos:  position{line: 264, col: 18, offset: 6271},
 								name: "BaseType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 262, col: 29, offset: 6149},
+								pos:  position{line: 264, col: 29, offset: 6282},
 								name: "ContainerType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 262, col: 45, offset: 6165},
+								pos:  position{line: 264, col: 45, offset: 6298},
 								name: "Identifier",
 							},
 						},
@@ -1143,22 +1166,22 @@ var g = &grammar{
 		},
 		{
 			name: "DefinitionType",
-			pos:  position{line: 269, col: 1, offset: 6275},
+			pos:  position{line: 271, col: 1, offset: 6408},
 			expr: &actionExpr{
-				pos: position{line: 269, col: 18, offset: 6294},
+				pos: position{line: 271, col: 18, offset: 6427},
 				run: (*parser).callonDefinitionType1,
 				expr: &labeledExpr{
-					pos:   position{line: 269, col: 18, offset: 6294},
+					pos:   position{line: 271, col: 18, offset: 6427},
 					label: "typ",
 					expr: &choiceExpr{
-						pos: position{line: 269, col: 23, offset: 6299},
+						pos: position{line: 271, col: 23, offset: 6432},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 269, col: 23, offset: 6299},
+								pos:  position{line: 271, col: 23, offset: 6432},
 								name: "BaseType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 269, col: 34, offset: 6310},
+								pos:  position{line: 271, col: 34, offset: 6443},
 								name: "ContainerType",
 							},
 						},
@@ -1168,32 +1191,32 @@ var g = &grammar{
 		},
 		{
 			name: "BaseType",
-			pos:  position{line: 273, col: 1, offset: 6347},
+			pos:  position{line: 275, col: 1, offset: 6480},
 			expr: &actionExpr{
-				pos: position{line: 273, col: 12, offset: 6360},
+				pos: position{line: 275, col: 12, offset: 6493},
 				run: (*parser).callonBaseType1,
 				expr: &seqExpr{
-					pos: position{line: 273, col: 12, offset: 6360},
+					pos: position{line: 275, col: 12, offset: 6493},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 273, col: 12, offset: 6360},
+							pos:   position{line: 275, col: 12, offset: 6493},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 273, col: 17, offset: 6365},
+								pos:  position{line: 275, col: 17, offset: 6498},
 								name: "BaseTypeName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 273, col: 30, offset: 6378},
+							pos:  position{line: 275, col: 30, offset: 6511},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 273, col: 33, offset: 6381},
+							pos:   position{line: 275, col: 33, offset: 6514},
 							label: "annotations",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 273, col: 45, offset: 6393},
+								pos: position{line: 275, col: 45, offset: 6526},
 								expr: &ruleRefExpr{
-									pos:  position{line: 273, col: 45, offset: 6393},
+									pos:  position{line: 275, col: 45, offset: 6526},
 									name: "TypeAnnotations",
 								},
 							},
@@ -1204,50 +1227,50 @@ var g = &grammar{
 		},
 		{
 			name: "BaseTypeName",
-			pos:  position{line: 280, col: 1, offset: 6504},
+			pos:  position{line: 282, col: 1, offset: 6637},
 			expr: &actionExpr{
-				pos: position{line: 280, col: 16, offset: 6521},
+				pos: position{line: 282, col: 16, offset: 6654},
 				run: (*parser).callonBaseTypeName1,
 				expr: &choiceExpr{
-					pos: position{line: 280, col: 17, offset: 6522},
+					pos: position{line: 282, col: 17, offset: 6655},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 280, col: 17, offset: 6522},
+							pos:        position{line: 282, col: 17, offset: 6655},
 							val:        "bool",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 280, col: 26, offset: 6531},
+							pos:        position{line: 282, col: 26, offset: 6664},
 							val:        "byte",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 280, col: 35, offset: 6540},
+							pos:        position{line: 282, col: 35, offset: 6673},
 							val:        "i16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 280, col: 43, offset: 6548},
+							pos:        position{line: 282, col: 43, offset: 6681},
 							val:        "i32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 280, col: 51, offset: 6556},
+							pos:        position{line: 282, col: 51, offset: 6689},
 							val:        "i64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 280, col: 59, offset: 6564},
+							pos:        position{line: 282, col: 59, offset: 6697},
 							val:        "double",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 280, col: 70, offset: 6575},
+							pos:        position{line: 282, col: 70, offset: 6708},
 							val:        "string",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 280, col: 81, offset: 6586},
+							pos:        position{line: 282, col: 81, offset: 6719},
 							val:        "binary",
 							ignoreCase: false,
 						},
@@ -1257,26 +1280,26 @@ var g = &grammar{
 		},
 		{
 			name: "ContainerType",
-			pos:  position{line: 284, col: 1, offset: 6630},
+			pos:  position{line: 286, col: 1, offset: 6763},
 			expr: &actionExpr{
-				pos: position{line: 284, col: 17, offset: 6648},
+				pos: position{line: 286, col: 17, offset: 6781},
 				run: (*parser).callonContainerType1,
 				expr: &labeledExpr{
-					pos:   position{line: 284, col: 17, offset: 6648},
+					pos:   position{line: 286, col: 17, offset: 6781},
 					label: "typ",
 					expr: &choiceExpr{
-						pos: position{line: 284, col: 22, offset: 6653},
+						pos: position{line: 286, col: 22, offset: 6786},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 284, col: 22, offset: 6653},
+								pos:  position{line: 286, col: 22, offset: 6786},
 								name: "MapType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 284, col: 32, offset: 6663},
+								pos:  position{line: 286, col: 32, offset: 6796},
 								name: "SetType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 284, col: 42, offset: 6673},
+								pos:  position{line: 286, col: 42, offset: 6806},
 								name: "ListType",
 							},
 						},
@@ -1286,87 +1309,87 @@ var g = &grammar{
 		},
 		{
 			name: "MapType",
-			pos:  position{line: 288, col: 1, offset: 6705},
+			pos:  position{line: 290, col: 1, offset: 6838},
 			expr: &actionExpr{
-				pos: position{line: 288, col: 11, offset: 6717},
+				pos: position{line: 290, col: 11, offset: 6850},
 				run: (*parser).callonMapType1,
 				expr: &seqExpr{
-					pos: position{line: 288, col: 11, offset: 6717},
+					pos: position{line: 290, col: 11, offset: 6850},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 288, col: 11, offset: 6717},
+							pos: position{line: 290, col: 11, offset: 6850},
 							expr: &ruleRefExpr{
-								pos:  position{line: 288, col: 11, offset: 6717},
+								pos:  position{line: 290, col: 11, offset: 6850},
 								name: "CppType",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 288, col: 20, offset: 6726},
+							pos:        position{line: 290, col: 20, offset: 6859},
 							val:        "map",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 288, col: 26, offset: 6732},
+							pos:  position{line: 290, col: 26, offset: 6865},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 288, col: 29, offset: 6735},
+							pos:        position{line: 290, col: 29, offset: 6868},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 288, col: 33, offset: 6739},
+							pos:  position{line: 290, col: 33, offset: 6872},
 							name: "WS",
 						},
 						&labeledExpr{
-							pos:   position{line: 288, col: 36, offset: 6742},
+							pos:   position{line: 290, col: 36, offset: 6875},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 288, col: 40, offset: 6746},
+								pos:  position{line: 290, col: 40, offset: 6879},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 288, col: 50, offset: 6756},
+							pos:  position{line: 290, col: 50, offset: 6889},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 288, col: 53, offset: 6759},
+							pos:        position{line: 290, col: 53, offset: 6892},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 288, col: 57, offset: 6763},
+							pos:  position{line: 290, col: 57, offset: 6896},
 							name: "WS",
 						},
 						&labeledExpr{
-							pos:   position{line: 288, col: 60, offset: 6766},
+							pos:   position{line: 290, col: 60, offset: 6899},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 288, col: 66, offset: 6772},
+								pos:  position{line: 290, col: 66, offset: 6905},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 288, col: 76, offset: 6782},
+							pos:  position{line: 290, col: 76, offset: 6915},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 288, col: 79, offset: 6785},
+							pos:        position{line: 290, col: 79, offset: 6918},
 							val:        ">",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 288, col: 83, offset: 6789},
+							pos:  position{line: 290, col: 83, offset: 6922},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 288, col: 86, offset: 6792},
+							pos:   position{line: 290, col: 86, offset: 6925},
 							label: "annotations",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 288, col: 98, offset: 6804},
+								pos: position{line: 290, col: 98, offset: 6937},
 								expr: &ruleRefExpr{
-									pos:  position{line: 288, col: 98, offset: 6804},
+									pos:  position{line: 290, col: 98, offset: 6937},
 									name: "TypeAnnotations",
 								},
 							},
@@ -1377,66 +1400,66 @@ var g = &grammar{
 		},
 		{
 			name: "SetType",
-			pos:  position{line: 297, col: 1, offset: 6959},
+			pos:  position{line: 299, col: 1, offset: 7092},
 			expr: &actionExpr{
-				pos: position{line: 297, col: 11, offset: 6971},
+				pos: position{line: 299, col: 11, offset: 7104},
 				run: (*parser).callonSetType1,
 				expr: &seqExpr{
-					pos: position{line: 297, col: 11, offset: 6971},
+					pos: position{line: 299, col: 11, offset: 7104},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 297, col: 11, offset: 6971},
+							pos: position{line: 299, col: 11, offset: 7104},
 							expr: &ruleRefExpr{
-								pos:  position{line: 297, col: 11, offset: 6971},
+								pos:  position{line: 299, col: 11, offset: 7104},
 								name: "CppType",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 297, col: 20, offset: 6980},
+							pos:        position{line: 299, col: 20, offset: 7113},
 							val:        "set",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 297, col: 26, offset: 6986},
+							pos:  position{line: 299, col: 26, offset: 7119},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 297, col: 29, offset: 6989},
+							pos:        position{line: 299, col: 29, offset: 7122},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 297, col: 33, offset: 6993},
+							pos:  position{line: 299, col: 33, offset: 7126},
 							name: "WS",
 						},
 						&labeledExpr{
-							pos:   position{line: 297, col: 36, offset: 6996},
+							pos:   position{line: 299, col: 36, offset: 7129},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 297, col: 40, offset: 7000},
+								pos:  position{line: 299, col: 40, offset: 7133},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 297, col: 50, offset: 7010},
+							pos:  position{line: 299, col: 50, offset: 7143},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 297, col: 53, offset: 7013},
+							pos:        position{line: 299, col: 53, offset: 7146},
 							val:        ">",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 297, col: 57, offset: 7017},
+							pos:  position{line: 299, col: 57, offset: 7150},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 297, col: 60, offset: 7020},
+							pos:   position{line: 299, col: 60, offset: 7153},
 							label: "annotations",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 297, col: 72, offset: 7032},
+								pos: position{line: 299, col: 72, offset: 7165},
 								expr: &ruleRefExpr{
-									pos:  position{line: 297, col: 72, offset: 7032},
+									pos:  position{line: 299, col: 72, offset: 7165},
 									name: "TypeAnnotations",
 								},
 							},
@@ -1447,59 +1470,59 @@ var g = &grammar{
 		},
 		{
 			name: "ListType",
-			pos:  position{line: 305, col: 1, offset: 7161},
+			pos:  position{line: 307, col: 1, offset: 7294},
 			expr: &actionExpr{
-				pos: position{line: 305, col: 12, offset: 7174},
+				pos: position{line: 307, col: 12, offset: 7307},
 				run: (*parser).callonListType1,
 				expr: &seqExpr{
-					pos: position{line: 305, col: 12, offset: 7174},
+					pos: position{line: 307, col: 12, offset: 7307},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 305, col: 12, offset: 7174},
+							pos:        position{line: 307, col: 12, offset: 7307},
 							val:        "list",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 305, col: 19, offset: 7181},
+							pos:  position{line: 307, col: 19, offset: 7314},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 305, col: 22, offset: 7184},
+							pos:        position{line: 307, col: 22, offset: 7317},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 305, col: 26, offset: 7188},
+							pos:  position{line: 307, col: 26, offset: 7321},
 							name: "WS",
 						},
 						&labeledExpr{
-							pos:   position{line: 305, col: 29, offset: 7191},
+							pos:   position{line: 307, col: 29, offset: 7324},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 305, col: 33, offset: 7195},
+								pos:  position{line: 307, col: 33, offset: 7328},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 305, col: 43, offset: 7205},
+							pos:  position{line: 307, col: 43, offset: 7338},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 305, col: 46, offset: 7208},
+							pos:        position{line: 307, col: 46, offset: 7341},
 							val:        ">",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 305, col: 50, offset: 7212},
+							pos:  position{line: 307, col: 50, offset: 7345},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 305, col: 53, offset: 7215},
+							pos:   position{line: 307, col: 53, offset: 7348},
 							label: "annotations",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 305, col: 65, offset: 7227},
+								pos: position{line: 307, col: 65, offset: 7360},
 								expr: &ruleRefExpr{
-									pos:  position{line: 305, col: 65, offset: 7227},
+									pos:  position{line: 307, col: 65, offset: 7360},
 									name: "TypeAnnotations",
 								},
 							},
@@ -1510,23 +1533,23 @@ var g = &grammar{
 		},
 		{
 			name: "CppType",
-			pos:  position{line: 313, col: 1, offset: 7357},
+			pos:  position{line: 315, col: 1, offset: 7490},
 			expr: &actionExpr{
-				pos: position{line: 313, col: 11, offset: 7369},
+				pos: position{line: 315, col: 11, offset: 7502},
 				run: (*parser).callonCppType1,
 				expr: &seqExpr{
-					pos: position{line: 313, col: 11, offset: 7369},
+					pos: position{line: 315, col: 11, offset: 7502},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 313, col: 11, offset: 7369},
+							pos:        position{line: 315, col: 11, offset: 7502},
 							val:        "cpp_type",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 313, col: 22, offset: 7380},
+							pos:   position{line: 315, col: 22, offset: 7513},
 							label: "cppType",
 							expr: &ruleRefExpr{
-								pos:  position{line: 313, col: 30, offset: 7388},
+								pos:  position{line: 315, col: 30, offset: 7521},
 								name: "Literal",
 							},
 						},
@@ -1536,32 +1559,32 @@ var g = &grammar{
 		},
 		{
 			name: "ConstValue",
-			pos:  position{line: 317, col: 1, offset: 7422},
+			pos:  position{line: 319, col: 1, offset: 7555},
 			expr: &choiceExpr{
-				pos: position{line: 317, col: 14, offset: 7437},
+				pos: position{line: 319, col: 14, offset: 7570},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 317, col: 14, offset: 7437},
+						pos:  position{line: 319, col: 14, offset: 7570},
 						name: "Literal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 317, col: 24, offset: 7447},
+						pos:  position{line: 319, col: 24, offset: 7580},
 						name: "DoubleConstant",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 317, col: 41, offset: 7464},
+						pos:  position{line: 319, col: 41, offset: 7597},
 						name: "IntConstant",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 317, col: 55, offset: 7478},
+						pos:  position{line: 319, col: 55, offset: 7611},
 						name: "ConstMap",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 317, col: 66, offset: 7489},
+						pos:  position{line: 319, col: 66, offset: 7622},
 						name: "ConstList",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 317, col: 78, offset: 7501},
+						pos:  position{line: 319, col: 78, offset: 7634},
 						name: "Identifier",
 					},
 				},
@@ -1569,35 +1592,35 @@ var g = &grammar{
 		},
 		{
 			name: "TypeAnnotations",
-			pos:  position{line: 319, col: 1, offset: 7513},
+			pos:  position{line: 321, col: 1, offset: 7646},
 			expr: &actionExpr{
-				pos: position{line: 319, col: 19, offset: 7533},
+				pos: position{line: 321, col: 19, offset: 7666},
 				run: (*parser).callonTypeAnnotations1,
 				expr: &seqExpr{
-					pos: position{line: 319, col: 19, offset: 7533},
+					pos: position{line: 321, col: 19, offset: 7666},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 319, col: 19, offset: 7533},
+							pos:        position{line: 321, col: 19, offset: 7666},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 319, col: 23, offset: 7537},
+							pos:  position{line: 321, col: 23, offset: 7670},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 319, col: 26, offset: 7540},
+							pos:   position{line: 321, col: 26, offset: 7673},
 							label: "annotations",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 319, col: 38, offset: 7552},
+								pos: position{line: 321, col: 38, offset: 7685},
 								expr: &ruleRefExpr{
-									pos:  position{line: 319, col: 38, offset: 7552},
+									pos:  position{line: 321, col: 38, offset: 7685},
 									name: "TypeAnnotation",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 319, col: 54, offset: 7568},
+							pos:        position{line: 321, col: 54, offset: 7701},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -1607,50 +1630,50 @@ var g = &grammar{
 		},
 		{
 			name: "TypeAnnotation",
-			pos:  position{line: 327, col: 1, offset: 7714},
+			pos:  position{line: 329, col: 1, offset: 7847},
 			expr: &actionExpr{
-				pos: position{line: 327, col: 18, offset: 7733},
+				pos: position{line: 329, col: 18, offset: 7866},
 				run: (*parser).callonTypeAnnotation1,
 				expr: &seqExpr{
-					pos: position{line: 327, col: 18, offset: 7733},
+					pos: position{line: 329, col: 18, offset: 7866},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 327, col: 18, offset: 7733},
+							pos:   position{line: 329, col: 18, offset: 7866},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 327, col: 23, offset: 7738},
+								pos:  position{line: 329, col: 23, offset: 7871},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 327, col: 34, offset: 7749},
+							pos:  position{line: 329, col: 34, offset: 7882},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 327, col: 36, offset: 7751},
+							pos:   position{line: 329, col: 36, offset: 7884},
 							label: "value",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 327, col: 42, offset: 7757},
+								pos: position{line: 329, col: 42, offset: 7890},
 								expr: &actionExpr{
-									pos: position{line: 327, col: 43, offset: 7758},
+									pos: position{line: 329, col: 43, offset: 7891},
 									run: (*parser).callonTypeAnnotation8,
 									expr: &seqExpr{
-										pos: position{line: 327, col: 43, offset: 7758},
+										pos: position{line: 329, col: 43, offset: 7891},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 327, col: 43, offset: 7758},
+												pos:        position{line: 329, col: 43, offset: 7891},
 												val:        "=",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 327, col: 47, offset: 7762},
+												pos:  position{line: 329, col: 47, offset: 7895},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 327, col: 50, offset: 7765},
+												pos:   position{line: 329, col: 50, offset: 7898},
 												label: "value",
 												expr: &ruleRefExpr{
-													pos:  position{line: 327, col: 56, offset: 7771},
+													pos:  position{line: 329, col: 56, offset: 7904},
 													name: "Literal",
 												},
 											},
@@ -1660,14 +1683,14 @@ var g = &grammar{
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 327, col: 88, offset: 7803},
+							pos: position{line: 329, col: 88, offset: 7936},
 							expr: &ruleRefExpr{
-								pos:  position{line: 327, col: 88, offset: 7803},
+								pos:  position{line: 329, col: 88, offset: 7936},
 								name: "ListSeparator",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 327, col: 103, offset: 7818},
+							pos:  position{line: 329, col: 103, offset: 7951},
 							name: "__",
 						},
 					},
@@ -1676,17 +1699,17 @@ var g = &grammar{
 		},
 		{
 			name: "IntConstant",
-			pos:  position{line: 338, col: 1, offset: 7981},
+			pos:  position{line: 340, col: 1, offset: 8114},
 			expr: &actionExpr{
-				pos: position{line: 338, col: 15, offset: 7997},
+				pos: position{line: 340, col: 15, offset: 8130},
 				run: (*parser).callonIntConstant1,
 				expr: &seqExpr{
-					pos: position{line: 338, col: 15, offset: 7997},
+					pos: position{line: 340, col: 15, offset: 8130},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 338, col: 15, offset: 7997},
+							pos: position{line: 340, col: 15, offset: 8130},
 							expr: &charClassMatcher{
-								pos:        position{line: 338, col: 15, offset: 7997},
+								pos:        position{line: 340, col: 15, offset: 8130},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -1694,9 +1717,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 338, col: 21, offset: 8003},
+							pos: position{line: 340, col: 21, offset: 8136},
 							expr: &ruleRefExpr{
-								pos:  position{line: 338, col: 21, offset: 8003},
+								pos:  position{line: 340, col: 21, offset: 8136},
 								name: "Digit",
 							},
 						},
@@ -1706,17 +1729,17 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleConstant",
-			pos:  position{line: 342, col: 1, offset: 8064},
+			pos:  position{line: 344, col: 1, offset: 8197},
 			expr: &actionExpr{
-				pos: position{line: 342, col: 18, offset: 8083},
+				pos: position{line: 344, col: 18, offset: 8216},
 				run: (*parser).callonDoubleConstant1,
 				expr: &seqExpr{
-					pos: position{line: 342, col: 18, offset: 8083},
+					pos: position{line: 344, col: 18, offset: 8216},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 342, col: 18, offset: 8083},
+							pos: position{line: 344, col: 18, offset: 8216},
 							expr: &charClassMatcher{
-								pos:        position{line: 342, col: 18, offset: 8083},
+								pos:        position{line: 344, col: 18, offset: 8216},
 								val:        "[+-]",
 								chars:      []rune{'+', '-'},
 								ignoreCase: false,
@@ -1724,38 +1747,38 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 342, col: 24, offset: 8089},
+							pos: position{line: 344, col: 24, offset: 8222},
 							expr: &ruleRefExpr{
-								pos:  position{line: 342, col: 24, offset: 8089},
+								pos:  position{line: 344, col: 24, offset: 8222},
 								name: "Digit",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 342, col: 31, offset: 8096},
+							pos:        position{line: 344, col: 31, offset: 8229},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 342, col: 35, offset: 8100},
+							pos: position{line: 344, col: 35, offset: 8233},
 							expr: &ruleRefExpr{
-								pos:  position{line: 342, col: 35, offset: 8100},
+								pos:  position{line: 344, col: 35, offset: 8233},
 								name: "Digit",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 342, col: 42, offset: 8107},
+							pos: position{line: 344, col: 42, offset: 8240},
 							expr: &seqExpr{
-								pos: position{line: 342, col: 44, offset: 8109},
+								pos: position{line: 344, col: 44, offset: 8242},
 								exprs: []interface{}{
 									&charClassMatcher{
-										pos:        position{line: 342, col: 44, offset: 8109},
+										pos:        position{line: 344, col: 44, offset: 8242},
 										val:        "['Ee']",
 										chars:      []rune{'\'', 'E', 'e', '\''},
 										ignoreCase: false,
 										inverted:   false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 342, col: 51, offset: 8116},
+										pos:  position{line: 344, col: 51, offset: 8249},
 										name: "IntConstant",
 									},
 								},
@@ -1767,47 +1790,47 @@ var g = &grammar{
 		},
 		{
 			name: "ConstList",
-			pos:  position{line: 346, col: 1, offset: 8183},
+			pos:  position{line: 348, col: 1, offset: 8316},
 			expr: &actionExpr{
-				pos: position{line: 346, col: 13, offset: 8197},
+				pos: position{line: 348, col: 13, offset: 8330},
 				run: (*parser).callonConstList1,
 				expr: &seqExpr{
-					pos: position{line: 346, col: 13, offset: 8197},
+					pos: position{line: 348, col: 13, offset: 8330},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 346, col: 13, offset: 8197},
+							pos:        position{line: 348, col: 13, offset: 8330},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 346, col: 17, offset: 8201},
+							pos:  position{line: 348, col: 17, offset: 8334},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 346, col: 20, offset: 8204},
+							pos:   position{line: 348, col: 20, offset: 8337},
 							label: "values",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 346, col: 27, offset: 8211},
+								pos: position{line: 348, col: 27, offset: 8344},
 								expr: &seqExpr{
-									pos: position{line: 346, col: 28, offset: 8212},
+									pos: position{line: 348, col: 28, offset: 8345},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 346, col: 28, offset: 8212},
+											pos:  position{line: 348, col: 28, offset: 8345},
 											name: "ConstValue",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 346, col: 39, offset: 8223},
+											pos:  position{line: 348, col: 39, offset: 8356},
 											name: "__",
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 346, col: 42, offset: 8226},
+											pos: position{line: 348, col: 42, offset: 8359},
 											expr: &ruleRefExpr{
-												pos:  position{line: 346, col: 42, offset: 8226},
+												pos:  position{line: 348, col: 42, offset: 8359},
 												name: "ListSeparator",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 346, col: 57, offset: 8241},
+											pos:  position{line: 348, col: 57, offset: 8374},
 											name: "__",
 										},
 									},
@@ -1815,11 +1838,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 346, col: 62, offset: 8246},
+							pos:  position{line: 348, col: 62, offset: 8379},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 346, col: 65, offset: 8249},
+							pos:        position{line: 348, col: 65, offset: 8382},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -1829,67 +1852,67 @@ var g = &grammar{
 		},
 		{
 			name: "ConstMap",
-			pos:  position{line: 355, col: 1, offset: 8422},
+			pos:  position{line: 357, col: 1, offset: 8555},
 			expr: &actionExpr{
-				pos: position{line: 355, col: 12, offset: 8435},
+				pos: position{line: 357, col: 12, offset: 8568},
 				run: (*parser).callonConstMap1,
 				expr: &seqExpr{
-					pos: position{line: 355, col: 12, offset: 8435},
+					pos: position{line: 357, col: 12, offset: 8568},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 355, col: 12, offset: 8435},
+							pos:        position{line: 357, col: 12, offset: 8568},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 355, col: 16, offset: 8439},
+							pos:  position{line: 357, col: 16, offset: 8572},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 355, col: 19, offset: 8442},
+							pos:   position{line: 357, col: 19, offset: 8575},
 							label: "values",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 355, col: 26, offset: 8449},
+								pos: position{line: 357, col: 26, offset: 8582},
 								expr: &seqExpr{
-									pos: position{line: 355, col: 27, offset: 8450},
+									pos: position{line: 357, col: 27, offset: 8583},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 355, col: 27, offset: 8450},
+											pos:  position{line: 357, col: 27, offset: 8583},
 											name: "ConstValue",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 355, col: 38, offset: 8461},
+											pos:  position{line: 357, col: 38, offset: 8594},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 355, col: 41, offset: 8464},
+											pos:        position{line: 357, col: 41, offset: 8597},
 											val:        ":",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 355, col: 45, offset: 8468},
+											pos:  position{line: 357, col: 45, offset: 8601},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 355, col: 48, offset: 8471},
+											pos:  position{line: 357, col: 48, offset: 8604},
 											name: "ConstValue",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 355, col: 59, offset: 8482},
+											pos:  position{line: 357, col: 59, offset: 8615},
 											name: "__",
 										},
 										&choiceExpr{
-											pos: position{line: 355, col: 63, offset: 8486},
+											pos: position{line: 357, col: 63, offset: 8619},
 											alternatives: []interface{}{
 												&litMatcher{
-													pos:        position{line: 355, col: 63, offset: 8486},
+													pos:        position{line: 357, col: 63, offset: 8619},
 													val:        ",",
 													ignoreCase: false,
 												},
 												&andExpr{
-													pos: position{line: 355, col: 69, offset: 8492},
+													pos: position{line: 357, col: 69, offset: 8625},
 													expr: &litMatcher{
-														pos:        position{line: 355, col: 70, offset: 8493},
+														pos:        position{line: 357, col: 70, offset: 8626},
 														val:        "}",
 														ignoreCase: false,
 													},
@@ -1897,7 +1920,7 @@ var g = &grammar{
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 355, col: 75, offset: 8498},
+											pos:  position{line: 357, col: 75, offset: 8631},
 											name: "__",
 										},
 									},
@@ -1905,7 +1928,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 355, col: 80, offset: 8503},
+							pos:        position{line: 357, col: 80, offset: 8636},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -1915,33 +1938,33 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 371, col: 1, offset: 8749},
+			pos:  position{line: 373, col: 1, offset: 8882},
 			expr: &actionExpr{
-				pos: position{line: 371, col: 11, offset: 8761},
+				pos: position{line: 373, col: 11, offset: 8894},
 				run: (*parser).callonLiteral1,
 				expr: &choiceExpr{
-					pos: position{line: 371, col: 12, offset: 8762},
+					pos: position{line: 373, col: 12, offset: 8895},
 					alternatives: []interface{}{
 						&seqExpr{
-							pos: position{line: 371, col: 13, offset: 8763},
+							pos: position{line: 373, col: 13, offset: 8896},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 371, col: 13, offset: 8763},
+									pos:        position{line: 373, col: 13, offset: 8896},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 371, col: 17, offset: 8767},
+									pos: position{line: 373, col: 17, offset: 8900},
 									expr: &choiceExpr{
-										pos: position{line: 371, col: 18, offset: 8768},
+										pos: position{line: 373, col: 18, offset: 8901},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 371, col: 18, offset: 8768},
+												pos:        position{line: 373, col: 18, offset: 8901},
 												val:        "\\\"",
 												ignoreCase: false,
 											},
 											&charClassMatcher{
-												pos:        position{line: 371, col: 25, offset: 8775},
+												pos:        position{line: 373, col: 25, offset: 8908},
 												val:        "[^\"]",
 												chars:      []rune{'"'},
 												ignoreCase: false,
@@ -1951,32 +1974,32 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 371, col: 32, offset: 8782},
+									pos:        position{line: 373, col: 32, offset: 8915},
 									val:        "\"",
 									ignoreCase: false,
 								},
 							},
 						},
 						&seqExpr{
-							pos: position{line: 371, col: 40, offset: 8790},
+							pos: position{line: 373, col: 40, offset: 8923},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 371, col: 40, offset: 8790},
+									pos:        position{line: 373, col: 40, offset: 8923},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 371, col: 45, offset: 8795},
+									pos: position{line: 373, col: 45, offset: 8928},
 									expr: &choiceExpr{
-										pos: position{line: 371, col: 46, offset: 8796},
+										pos: position{line: 373, col: 46, offset: 8929},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 371, col: 46, offset: 8796},
+												pos:        position{line: 373, col: 46, offset: 8929},
 												val:        "\\'",
 												ignoreCase: false,
 											},
 											&charClassMatcher{
-												pos:        position{line: 371, col: 53, offset: 8803},
+												pos:        position{line: 373, col: 53, offset: 8936},
 												val:        "[^']",
 												chars:      []rune{'\''},
 												ignoreCase: false,
@@ -1986,7 +2009,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 371, col: 60, offset: 8810},
+									pos:        position{line: 373, col: 60, offset: 8943},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -1998,24 +2021,24 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 378, col: 1, offset: 9011},
+			pos:  position{line: 380, col: 1, offset: 9144},
 			expr: &actionExpr{
-				pos: position{line: 378, col: 14, offset: 9026},
+				pos: position{line: 380, col: 14, offset: 9159},
 				run: (*parser).callonIdentifier1,
 				expr: &seqExpr{
-					pos: position{line: 378, col: 14, offset: 9026},
+					pos: position{line: 380, col: 14, offset: 9159},
 					exprs: []interface{}{
 						&oneOrMoreExpr{
-							pos: position{line: 378, col: 14, offset: 9026},
+							pos: position{line: 380, col: 14, offset: 9159},
 							expr: &choiceExpr{
-								pos: position{line: 378, col: 15, offset: 9027},
+								pos: position{line: 380, col: 15, offset: 9160},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 378, col: 15, offset: 9027},
+										pos:  position{line: 380, col: 15, offset: 9160},
 										name: "Letter",
 									},
 									&litMatcher{
-										pos:        position{line: 378, col: 24, offset: 9036},
+										pos:        position{line: 380, col: 24, offset: 9169},
 										val:        "_",
 										ignoreCase: false,
 									},
@@ -2023,20 +2046,20 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 378, col: 30, offset: 9042},
+							pos: position{line: 380, col: 30, offset: 9175},
 							expr: &choiceExpr{
-								pos: position{line: 378, col: 31, offset: 9043},
+								pos: position{line: 380, col: 31, offset: 9176},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 378, col: 31, offset: 9043},
+										pos:  position{line: 380, col: 31, offset: 9176},
 										name: "Letter",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 378, col: 40, offset: 9052},
+										pos:  position{line: 380, col: 40, offset: 9185},
 										name: "Digit",
 									},
 									&charClassMatcher{
-										pos:        position{line: 378, col: 48, offset: 9060},
+										pos:        position{line: 380, col: 48, offset: 9193},
 										val:        "[._]",
 										chars:      []rune{'.', '_'},
 										ignoreCase: false,
@@ -2051,9 +2074,9 @@ var g = &grammar{
 		},
 		{
 			name: "ListSeparator",
-			pos:  position{line: 382, col: 1, offset: 9112},
+			pos:  position{line: 384, col: 1, offset: 9245},
 			expr: &charClassMatcher{
-				pos:        position{line: 382, col: 17, offset: 9130},
+				pos:        position{line: 384, col: 17, offset: 9263},
 				val:        "[,;]",
 				chars:      []rune{',', ';'},
 				ignoreCase: false,
@@ -2062,9 +2085,9 @@ var g = &grammar{
 		},
 		{
 			name: "Letter",
-			pos:  position{line: 383, col: 1, offset: 9135},
+			pos:  position{line: 385, col: 1, offset: 9268},
 			expr: &charClassMatcher{
-				pos:        position{line: 383, col: 10, offset: 9146},
+				pos:        position{line: 385, col: 10, offset: 9279},
 				val:        "[A-Za-z]",
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
 				ignoreCase: false,
@@ -2073,9 +2096,9 @@ var g = &grammar{
 		},
 		{
 			name: "Digit",
-			pos:  position{line: 384, col: 1, offset: 9155},
+			pos:  position{line: 386, col: 1, offset: 9288},
 			expr: &charClassMatcher{
-				pos:        position{line: 384, col: 9, offset: 9165},
+				pos:        position{line: 386, col: 9, offset: 9298},
 				val:        "[0-9]",
 				ranges:     []rune{'0', '9'},
 				ignoreCase: false,
@@ -2084,23 +2107,23 @@ var g = &grammar{
 		},
 		{
 			name: "SourceChar",
-			pos:  position{line: 388, col: 1, offset: 9176},
+			pos:  position{line: 390, col: 1, offset: 9309},
 			expr: &anyMatcher{
-				line: 388, col: 14, offset: 9191,
+				line: 390, col: 14, offset: 9324,
 			},
 		},
 		{
 			name: "Comment",
-			pos:  position{line: 389, col: 1, offset: 9193},
+			pos:  position{line: 391, col: 1, offset: 9326},
 			expr: &choiceExpr{
-				pos: position{line: 389, col: 11, offset: 9205},
+				pos: position{line: 391, col: 11, offset: 9338},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 389, col: 11, offset: 9205},
+						pos:  position{line: 391, col: 11, offset: 9338},
 						name: "MultiLineComment",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 389, col: 30, offset: 9224},
+						pos:  position{line: 391, col: 30, offset: 9357},
 						name: "SingleLineComment",
 					},
 				},
@@ -2108,37 +2131,37 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 390, col: 1, offset: 9242},
+			pos:  position{line: 392, col: 1, offset: 9375},
 			expr: &seqExpr{
-				pos: position{line: 390, col: 20, offset: 9263},
+				pos: position{line: 392, col: 20, offset: 9396},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 390, col: 20, offset: 9263},
+						pos:        position{line: 392, col: 20, offset: 9396},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 390, col: 25, offset: 9268},
+						pos: position{line: 392, col: 25, offset: 9401},
 						expr: &seqExpr{
-							pos: position{line: 390, col: 27, offset: 9270},
+							pos: position{line: 392, col: 27, offset: 9403},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 390, col: 27, offset: 9270},
+									pos: position{line: 392, col: 27, offset: 9403},
 									expr: &litMatcher{
-										pos:        position{line: 390, col: 28, offset: 9271},
+										pos:        position{line: 392, col: 28, offset: 9404},
 										val:        "*/",
 										ignoreCase: false,
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 390, col: 33, offset: 9276},
+									pos:  position{line: 392, col: 33, offset: 9409},
 									name: "SourceChar",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 390, col: 47, offset: 9290},
+						pos:        position{line: 392, col: 47, offset: 9423},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -2147,46 +2170,46 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineCommentNoLineTerminator",
-			pos:  position{line: 391, col: 1, offset: 9295},
+			pos:  position{line: 393, col: 1, offset: 9428},
 			expr: &seqExpr{
-				pos: position{line: 391, col: 36, offset: 9332},
+				pos: position{line: 393, col: 36, offset: 9465},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 391, col: 36, offset: 9332},
+						pos:        position{line: 393, col: 36, offset: 9465},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 391, col: 41, offset: 9337},
+						pos: position{line: 393, col: 41, offset: 9470},
 						expr: &seqExpr{
-							pos: position{line: 391, col: 43, offset: 9339},
+							pos: position{line: 393, col: 43, offset: 9472},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 391, col: 43, offset: 9339},
+									pos: position{line: 393, col: 43, offset: 9472},
 									expr: &choiceExpr{
-										pos: position{line: 391, col: 46, offset: 9342},
+										pos: position{line: 393, col: 46, offset: 9475},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 391, col: 46, offset: 9342},
+												pos:        position{line: 393, col: 46, offset: 9475},
 												val:        "*/",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 391, col: 53, offset: 9349},
+												pos:  position{line: 393, col: 53, offset: 9482},
 												name: "EOL",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 391, col: 59, offset: 9355},
+									pos:  position{line: 393, col: 59, offset: 9488},
 									name: "SourceChar",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 391, col: 73, offset: 9369},
+						pos:        position{line: 393, col: 73, offset: 9502},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -2195,32 +2218,32 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 392, col: 1, offset: 9374},
+			pos:  position{line: 394, col: 1, offset: 9507},
 			expr: &choiceExpr{
-				pos: position{line: 392, col: 21, offset: 9396},
+				pos: position{line: 394, col: 21, offset: 9529},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 392, col: 22, offset: 9397},
+						pos: position{line: 394, col: 22, offset: 9530},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 392, col: 22, offset: 9397},
+								pos:        position{line: 394, col: 22, offset: 9530},
 								val:        "//",
 								ignoreCase: false,
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 392, col: 27, offset: 9402},
+								pos: position{line: 394, col: 27, offset: 9535},
 								expr: &seqExpr{
-									pos: position{line: 392, col: 29, offset: 9404},
+									pos: position{line: 394, col: 29, offset: 9537},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 392, col: 29, offset: 9404},
+											pos: position{line: 394, col: 29, offset: 9537},
 											expr: &ruleRefExpr{
-												pos:  position{line: 392, col: 30, offset: 9405},
+												pos:  position{line: 394, col: 30, offset: 9538},
 												name: "EOL",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 392, col: 34, offset: 9409},
+											pos:  position{line: 394, col: 34, offset: 9542},
 											name: "SourceChar",
 										},
 									},
@@ -2229,27 +2252,27 @@ var g = &grammar{
 						},
 					},
 					&seqExpr{
-						pos: position{line: 392, col: 52, offset: 9427},
+						pos: position{line: 394, col: 52, offset: 9560},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 392, col: 52, offset: 9427},
+								pos:        position{line: 394, col: 52, offset: 9560},
 								val:        "#",
 								ignoreCase: false,
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 392, col: 56, offset: 9431},
+								pos: position{line: 394, col: 56, offset: 9564},
 								expr: &seqExpr{
-									pos: position{line: 392, col: 58, offset: 9433},
+									pos: position{line: 394, col: 58, offset: 9566},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 392, col: 58, offset: 9433},
+											pos: position{line: 394, col: 58, offset: 9566},
 											expr: &ruleRefExpr{
-												pos:  position{line: 392, col: 59, offset: 9434},
+												pos:  position{line: 394, col: 59, offset: 9567},
 												name: "EOL",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 392, col: 63, offset: 9438},
+											pos:  position{line: 394, col: 63, offset: 9571},
 											name: "SourceChar",
 										},
 									},
@@ -2262,22 +2285,22 @@ var g = &grammar{
 		},
 		{
 			name: "__",
-			pos:  position{line: 394, col: 1, offset: 9454},
+			pos:  position{line: 396, col: 1, offset: 9587},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 394, col: 6, offset: 9461},
+				pos: position{line: 396, col: 6, offset: 9594},
 				expr: &choiceExpr{
-					pos: position{line: 394, col: 8, offset: 9463},
+					pos: position{line: 396, col: 8, offset: 9596},
 					alternatives: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 394, col: 8, offset: 9463},
+							pos:  position{line: 396, col: 8, offset: 9596},
 							name: "Whitespace",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 394, col: 21, offset: 9476},
+							pos:  position{line: 396, col: 21, offset: 9609},
 							name: "EOL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 394, col: 27, offset: 9482},
+							pos:  position{line: 396, col: 27, offset: 9615},
 							name: "Comment",
 						},
 					},
@@ -2286,18 +2309,18 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 395, col: 1, offset: 9493},
+			pos:  position{line: 397, col: 1, offset: 9626},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 395, col: 5, offset: 9499},
+				pos: position{line: 397, col: 5, offset: 9632},
 				expr: &choiceExpr{
-					pos: position{line: 395, col: 7, offset: 9501},
+					pos: position{line: 397, col: 7, offset: 9634},
 					alternatives: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 395, col: 7, offset: 9501},
+							pos:  position{line: 397, col: 7, offset: 9634},
 							name: "Whitespace",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 395, col: 20, offset: 9514},
+							pos:  position{line: 397, col: 20, offset: 9647},
 							name: "MultiLineCommentNoLineTerminator",
 						},
 					},
@@ -2306,20 +2329,20 @@ var g = &grammar{
 		},
 		{
 			name: "WS",
-			pos:  position{line: 396, col: 1, offset: 9550},
+			pos:  position{line: 398, col: 1, offset: 9683},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 396, col: 6, offset: 9557},
+				pos: position{line: 398, col: 6, offset: 9690},
 				expr: &ruleRefExpr{
-					pos:  position{line: 396, col: 6, offset: 9557},
+					pos:  position{line: 398, col: 6, offset: 9690},
 					name: "Whitespace",
 				},
 			},
 		},
 		{
 			name: "Whitespace",
-			pos:  position{line: 398, col: 1, offset: 9570},
+			pos:  position{line: 400, col: 1, offset: 9703},
 			expr: &charClassMatcher{
-				pos:        position{line: 398, col: 14, offset: 9585},
+				pos:        position{line: 400, col: 14, offset: 9718},
 				val:        "[ \\t\\r]",
 				chars:      []rune{' ', '\t', '\r'},
 				ignoreCase: false,
@@ -2328,62 +2351,62 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 399, col: 1, offset: 9593},
+			pos:  position{line: 401, col: 1, offset: 9726},
 			expr: &litMatcher{
-				pos:        position{line: 399, col: 7, offset: 9601},
+				pos:        position{line: 401, col: 7, offset: 9734},
 				val:        "\n",
 				ignoreCase: false,
 			},
 		},
 		{
 			name: "EOS",
-			pos:  position{line: 400, col: 1, offset: 9606},
+			pos:  position{line: 402, col: 1, offset: 9739},
 			expr: &choiceExpr{
-				pos: position{line: 400, col: 7, offset: 9614},
+				pos: position{line: 402, col: 7, offset: 9747},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 400, col: 7, offset: 9614},
+						pos: position{line: 402, col: 7, offset: 9747},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 400, col: 7, offset: 9614},
+								pos:  position{line: 402, col: 7, offset: 9747},
 								name: "__",
 							},
 							&litMatcher{
-								pos:        position{line: 400, col: 10, offset: 9617},
+								pos:        position{line: 402, col: 10, offset: 9750},
 								val:        ";",
 								ignoreCase: false,
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 400, col: 16, offset: 9623},
+						pos: position{line: 402, col: 16, offset: 9756},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 400, col: 16, offset: 9623},
+								pos:  position{line: 402, col: 16, offset: 9756},
 								name: "_",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 400, col: 18, offset: 9625},
+								pos: position{line: 402, col: 18, offset: 9758},
 								expr: &ruleRefExpr{
-									pos:  position{line: 400, col: 18, offset: 9625},
+									pos:  position{line: 402, col: 18, offset: 9758},
 									name: "SingleLineComment",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 400, col: 37, offset: 9644},
+								pos:  position{line: 402, col: 37, offset: 9777},
 								name: "EOL",
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 400, col: 43, offset: 9650},
+						pos: position{line: 402, col: 43, offset: 9783},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 400, col: 43, offset: 9650},
+								pos:  position{line: 402, col: 43, offset: 9783},
 								name: "__",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 400, col: 46, offset: 9653},
+								pos:  position{line: 402, col: 46, offset: 9786},
 								name: "EOF",
 							},
 						},
@@ -2393,11 +2416,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 402, col: 1, offset: 9658},
+			pos:  position{line: 404, col: 1, offset: 9791},
 			expr: &notExpr{
-				pos: position{line: 402, col: 7, offset: 9666},
+				pos: position{line: 404, col: 7, offset: 9799},
 				expr: &anyMatcher{
-					line: 402, col: 8, offset: 9667,
+					line: 404, col: 8, offset: 9800,
 				},
 			},
 		},
@@ -2501,11 +2524,12 @@ func (p *parser) callonConst1() (interface{}, error) {
 	return p.cur.onConst1(stack["typ"], stack["name"], stack["value"])
 }
 
-func (c *current) onEnum1(name, values interface{}) (interface{}, error) {
+func (c *current) onEnum1(name, values, annotations interface{}) (interface{}, error) {
 	vs := toIfaceSlice(values)
 	en := &Enum{
-		Name:   string(name.(Identifier)),
-		Values: make(map[string]*EnumValue, len(vs)),
+		Name:        string(name.(Identifier)),
+		Values:      make(map[string]*EnumValue, len(vs)),
+		Annotations: toAnnotations(annotations),
 	}
 	// Assigns numbers in order. This will behave badly if some values are
 	// defined and other are not, but I think that's ok since that's a silly
@@ -2527,13 +2551,14 @@ func (c *current) onEnum1(name, values interface{}) (interface{}, error) {
 func (p *parser) callonEnum1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onEnum1(stack["name"], stack["values"])
+	return p.cur.onEnum1(stack["name"], stack["values"], stack["annotations"])
 }
 
-func (c *current) onEnumValue1(name, value interface{}) (interface{}, error) {
+func (c *current) onEnumValue1(name, value, annotations interface{}) (interface{}, error) {
 	ev := &EnumValue{
-		Name:  string(name.(Identifier)),
-		Value: -1,
+		Name:        string(name.(Identifier)),
+		Value:       -1,
+		Annotations: toAnnotations(annotations),
 	}
 	if value != nil {
 		ev.Value = int(value.([]interface{})[2].(int64))
@@ -2544,7 +2569,7 @@ func (c *current) onEnumValue1(name, value interface{}) (interface{}, error) {
 func (p *parser) callonEnumValue1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onEnumValue1(stack["name"], stack["value"])
+	return p.cur.onEnumValue1(stack["name"], stack["value"], stack["annotations"])
 }
 
 func (c *current) onTypeDef1(typ, name, annotations interface{}) (interface{}, error) {

--- a/parser/grammar.peg.go
+++ b/parser/grammar.peg.go
@@ -961,6 +961,21 @@ var g = &grammar{
 						},
 						&ruleRefExpr{
 							pos:  position{line: 212, col: 138, offset: 5169},
+							name: "__",
+						},
+						&labeledExpr{
+							pos:   position{line: 212, col: 141, offset: 5172},
+							label: "annotations",
+							expr: &zeroOrOneExpr{
+								pos: position{line: 212, col: 153, offset: 5184},
+								expr: &ruleRefExpr{
+									pos:  position{line: 212, col: 153, offset: 5184},
+									name: "TypeAnnotations",
+								},
+							},
+						},
+						&ruleRefExpr{
+							pos:  position{line: 212, col: 171, offset: 5202},
 							name: "EOS",
 						},
 					},
@@ -969,39 +984,39 @@ var g = &grammar{
 		},
 		{
 			name: "EndOfServiceError",
-			pos:  position{line: 227, col: 1, offset: 5510},
+			pos:  position{line: 228, col: 1, offset: 5586},
 			expr: &actionExpr{
-				pos: position{line: 227, col: 21, offset: 5532},
+				pos: position{line: 228, col: 21, offset: 5608},
 				run: (*parser).callonEndOfServiceError1,
 				expr: &anyMatcher{
-					line: 227, col: 21, offset: 5532,
+					line: 228, col: 21, offset: 5608,
 				},
 			},
 		},
 		{
 			name: "Function",
-			pos:  position{line: 231, col: 1, offset: 5598},
+			pos:  position{line: 232, col: 1, offset: 5674},
 			expr: &actionExpr{
-				pos: position{line: 231, col: 12, offset: 5611},
+				pos: position{line: 232, col: 12, offset: 5687},
 				run: (*parser).callonFunction1,
 				expr: &seqExpr{
-					pos: position{line: 231, col: 12, offset: 5611},
+					pos: position{line: 232, col: 12, offset: 5687},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 231, col: 12, offset: 5611},
+							pos:   position{line: 232, col: 12, offset: 5687},
 							label: "oneway",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 231, col: 19, offset: 5618},
+								pos: position{line: 232, col: 19, offset: 5694},
 								expr: &seqExpr{
-									pos: position{line: 231, col: 20, offset: 5619},
+									pos: position{line: 232, col: 20, offset: 5695},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 231, col: 20, offset: 5619},
+											pos:        position{line: 232, col: 20, offset: 5695},
 											val:        "oneway",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 231, col: 29, offset: 5628},
+											pos:  position{line: 232, col: 29, offset: 5704},
 											name: "__",
 										},
 									},
@@ -1009,70 +1024,85 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 231, col: 34, offset: 5633},
+							pos:   position{line: 232, col: 34, offset: 5709},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 231, col: 38, offset: 5637},
+								pos:  position{line: 232, col: 38, offset: 5713},
 								name: "FunctionType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 231, col: 51, offset: 5650},
+							pos:  position{line: 232, col: 51, offset: 5726},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 231, col: 54, offset: 5653},
+							pos:   position{line: 232, col: 54, offset: 5729},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 231, col: 59, offset: 5658},
+								pos:  position{line: 232, col: 59, offset: 5734},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 231, col: 70, offset: 5669},
+							pos:  position{line: 232, col: 70, offset: 5745},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 231, col: 72, offset: 5671},
+							pos:        position{line: 232, col: 72, offset: 5747},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 231, col: 76, offset: 5675},
+							pos:  position{line: 232, col: 76, offset: 5751},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 231, col: 79, offset: 5678},
+							pos:   position{line: 232, col: 79, offset: 5754},
 							label: "arguments",
 							expr: &ruleRefExpr{
-								pos:  position{line: 231, col: 89, offset: 5688},
+								pos:  position{line: 232, col: 89, offset: 5764},
 								name: "FieldList",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 231, col: 99, offset: 5698},
+							pos:        position{line: 232, col: 99, offset: 5774},
 							val:        ")",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 231, col: 103, offset: 5702},
+							pos:  position{line: 232, col: 103, offset: 5778},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 231, col: 106, offset: 5705},
+							pos:   position{line: 232, col: 106, offset: 5781},
 							label: "exceptions",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 231, col: 117, offset: 5716},
+								pos: position{line: 232, col: 117, offset: 5792},
 								expr: &ruleRefExpr{
-									pos:  position{line: 231, col: 117, offset: 5716},
+									pos:  position{line: 232, col: 117, offset: 5792},
 									name: "Throws",
 								},
 							},
 						},
+						&ruleRefExpr{
+							pos:  position{line: 232, col: 125, offset: 5800},
+							name: "__",
+						},
+						&labeledExpr{
+							pos:   position{line: 232, col: 128, offset: 5803},
+							label: "annotations",
+							expr: &zeroOrOneExpr{
+								pos: position{line: 232, col: 140, offset: 5815},
+								expr: &ruleRefExpr{
+									pos:  position{line: 232, col: 140, offset: 5815},
+									name: "TypeAnnotations",
+								},
+							},
+						},
 						&zeroOrOneExpr{
-							pos: position{line: 231, col: 125, offset: 5724},
+							pos: position{line: 232, col: 157, offset: 5832},
 							expr: &ruleRefExpr{
-								pos:  position{line: 231, col: 125, offset: 5724},
+								pos:  position{line: 232, col: 157, offset: 5832},
 								name: "ListSeparator",
 							},
 						},
@@ -1082,23 +1112,23 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionType",
-			pos:  position{line: 254, col: 1, offset: 6105},
+			pos:  position{line: 256, col: 1, offset: 6256},
 			expr: &actionExpr{
-				pos: position{line: 254, col: 16, offset: 6122},
+				pos: position{line: 256, col: 16, offset: 6273},
 				run: (*parser).callonFunctionType1,
 				expr: &labeledExpr{
-					pos:   position{line: 254, col: 16, offset: 6122},
+					pos:   position{line: 256, col: 16, offset: 6273},
 					label: "typ",
 					expr: &choiceExpr{
-						pos: position{line: 254, col: 21, offset: 6127},
+						pos: position{line: 256, col: 21, offset: 6278},
 						alternatives: []interface{}{
 							&litMatcher{
-								pos:        position{line: 254, col: 21, offset: 6127},
+								pos:        position{line: 256, col: 21, offset: 6278},
 								val:        "void",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 254, col: 30, offset: 6136},
+								pos:  position{line: 256, col: 30, offset: 6287},
 								name: "FieldType",
 							},
 						},
@@ -1108,41 +1138,41 @@ var g = &grammar{
 		},
 		{
 			name: "Throws",
-			pos:  position{line: 261, col: 1, offset: 6243},
+			pos:  position{line: 263, col: 1, offset: 6394},
 			expr: &actionExpr{
-				pos: position{line: 261, col: 10, offset: 6254},
+				pos: position{line: 263, col: 10, offset: 6405},
 				run: (*parser).callonThrows1,
 				expr: &seqExpr{
-					pos: position{line: 261, col: 10, offset: 6254},
+					pos: position{line: 263, col: 10, offset: 6405},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 261, col: 10, offset: 6254},
+							pos:        position{line: 263, col: 10, offset: 6405},
 							val:        "throws",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 261, col: 19, offset: 6263},
+							pos:  position{line: 263, col: 19, offset: 6414},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 261, col: 22, offset: 6266},
+							pos:        position{line: 263, col: 22, offset: 6417},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 261, col: 26, offset: 6270},
+							pos:  position{line: 263, col: 26, offset: 6421},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 261, col: 29, offset: 6273},
+							pos:   position{line: 263, col: 29, offset: 6424},
 							label: "exceptions",
 							expr: &ruleRefExpr{
-								pos:  position{line: 261, col: 40, offset: 6284},
+								pos:  position{line: 263, col: 40, offset: 6435},
 								name: "FieldList",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 261, col: 50, offset: 6294},
+							pos:        position{line: 263, col: 50, offset: 6445},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -1152,26 +1182,26 @@ var g = &grammar{
 		},
 		{
 			name: "FieldType",
-			pos:  position{line: 265, col: 1, offset: 6327},
+			pos:  position{line: 267, col: 1, offset: 6478},
 			expr: &actionExpr{
-				pos: position{line: 265, col: 13, offset: 6341},
+				pos: position{line: 267, col: 13, offset: 6492},
 				run: (*parser).callonFieldType1,
 				expr: &labeledExpr{
-					pos:   position{line: 265, col: 13, offset: 6341},
+					pos:   position{line: 267, col: 13, offset: 6492},
 					label: "typ",
 					expr: &choiceExpr{
-						pos: position{line: 265, col: 18, offset: 6346},
+						pos: position{line: 267, col: 18, offset: 6497},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 265, col: 18, offset: 6346},
+								pos:  position{line: 267, col: 18, offset: 6497},
 								name: "BaseType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 265, col: 29, offset: 6357},
+								pos:  position{line: 267, col: 29, offset: 6508},
 								name: "ContainerType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 265, col: 45, offset: 6373},
+								pos:  position{line: 267, col: 45, offset: 6524},
 								name: "Identifier",
 							},
 						},
@@ -1181,22 +1211,22 @@ var g = &grammar{
 		},
 		{
 			name: "DefinitionType",
-			pos:  position{line: 272, col: 1, offset: 6483},
+			pos:  position{line: 274, col: 1, offset: 6634},
 			expr: &actionExpr{
-				pos: position{line: 272, col: 18, offset: 6502},
+				pos: position{line: 274, col: 18, offset: 6653},
 				run: (*parser).callonDefinitionType1,
 				expr: &labeledExpr{
-					pos:   position{line: 272, col: 18, offset: 6502},
+					pos:   position{line: 274, col: 18, offset: 6653},
 					label: "typ",
 					expr: &choiceExpr{
-						pos: position{line: 272, col: 23, offset: 6507},
+						pos: position{line: 274, col: 23, offset: 6658},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 272, col: 23, offset: 6507},
+								pos:  position{line: 274, col: 23, offset: 6658},
 								name: "BaseType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 272, col: 34, offset: 6518},
+								pos:  position{line: 274, col: 34, offset: 6669},
 								name: "ContainerType",
 							},
 						},
@@ -1206,32 +1236,32 @@ var g = &grammar{
 		},
 		{
 			name: "BaseType",
-			pos:  position{line: 276, col: 1, offset: 6555},
+			pos:  position{line: 278, col: 1, offset: 6706},
 			expr: &actionExpr{
-				pos: position{line: 276, col: 12, offset: 6568},
+				pos: position{line: 278, col: 12, offset: 6719},
 				run: (*parser).callonBaseType1,
 				expr: &seqExpr{
-					pos: position{line: 276, col: 12, offset: 6568},
+					pos: position{line: 278, col: 12, offset: 6719},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 276, col: 12, offset: 6568},
+							pos:   position{line: 278, col: 12, offset: 6719},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 276, col: 17, offset: 6573},
+								pos:  position{line: 278, col: 17, offset: 6724},
 								name: "BaseTypeName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 276, col: 30, offset: 6586},
+							pos:  position{line: 278, col: 30, offset: 6737},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 276, col: 33, offset: 6589},
+							pos:   position{line: 278, col: 33, offset: 6740},
 							label: "annotations",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 276, col: 45, offset: 6601},
+								pos: position{line: 278, col: 45, offset: 6752},
 								expr: &ruleRefExpr{
-									pos:  position{line: 276, col: 45, offset: 6601},
+									pos:  position{line: 278, col: 45, offset: 6752},
 									name: "TypeAnnotations",
 								},
 							},
@@ -1242,50 +1272,50 @@ var g = &grammar{
 		},
 		{
 			name: "BaseTypeName",
-			pos:  position{line: 283, col: 1, offset: 6712},
+			pos:  position{line: 285, col: 1, offset: 6863},
 			expr: &actionExpr{
-				pos: position{line: 283, col: 16, offset: 6729},
+				pos: position{line: 285, col: 16, offset: 6880},
 				run: (*parser).callonBaseTypeName1,
 				expr: &choiceExpr{
-					pos: position{line: 283, col: 17, offset: 6730},
+					pos: position{line: 285, col: 17, offset: 6881},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 283, col: 17, offset: 6730},
+							pos:        position{line: 285, col: 17, offset: 6881},
 							val:        "bool",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 283, col: 26, offset: 6739},
+							pos:        position{line: 285, col: 26, offset: 6890},
 							val:        "byte",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 283, col: 35, offset: 6748},
+							pos:        position{line: 285, col: 35, offset: 6899},
 							val:        "i16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 283, col: 43, offset: 6756},
+							pos:        position{line: 285, col: 43, offset: 6907},
 							val:        "i32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 283, col: 51, offset: 6764},
+							pos:        position{line: 285, col: 51, offset: 6915},
 							val:        "i64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 283, col: 59, offset: 6772},
+							pos:        position{line: 285, col: 59, offset: 6923},
 							val:        "double",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 283, col: 70, offset: 6783},
+							pos:        position{line: 285, col: 70, offset: 6934},
 							val:        "string",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 283, col: 81, offset: 6794},
+							pos:        position{line: 285, col: 81, offset: 6945},
 							val:        "binary",
 							ignoreCase: false,
 						},
@@ -1295,26 +1325,26 @@ var g = &grammar{
 		},
 		{
 			name: "ContainerType",
-			pos:  position{line: 287, col: 1, offset: 6838},
+			pos:  position{line: 289, col: 1, offset: 6989},
 			expr: &actionExpr{
-				pos: position{line: 287, col: 17, offset: 6856},
+				pos: position{line: 289, col: 17, offset: 7007},
 				run: (*parser).callonContainerType1,
 				expr: &labeledExpr{
-					pos:   position{line: 287, col: 17, offset: 6856},
+					pos:   position{line: 289, col: 17, offset: 7007},
 					label: "typ",
 					expr: &choiceExpr{
-						pos: position{line: 287, col: 22, offset: 6861},
+						pos: position{line: 289, col: 22, offset: 7012},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 287, col: 22, offset: 6861},
+								pos:  position{line: 289, col: 22, offset: 7012},
 								name: "MapType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 287, col: 32, offset: 6871},
+								pos:  position{line: 289, col: 32, offset: 7022},
 								name: "SetType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 287, col: 42, offset: 6881},
+								pos:  position{line: 289, col: 42, offset: 7032},
 								name: "ListType",
 							},
 						},
@@ -1324,87 +1354,87 @@ var g = &grammar{
 		},
 		{
 			name: "MapType",
-			pos:  position{line: 291, col: 1, offset: 6913},
+			pos:  position{line: 293, col: 1, offset: 7064},
 			expr: &actionExpr{
-				pos: position{line: 291, col: 11, offset: 6925},
+				pos: position{line: 293, col: 11, offset: 7076},
 				run: (*parser).callonMapType1,
 				expr: &seqExpr{
-					pos: position{line: 291, col: 11, offset: 6925},
+					pos: position{line: 293, col: 11, offset: 7076},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 291, col: 11, offset: 6925},
+							pos: position{line: 293, col: 11, offset: 7076},
 							expr: &ruleRefExpr{
-								pos:  position{line: 291, col: 11, offset: 6925},
+								pos:  position{line: 293, col: 11, offset: 7076},
 								name: "CppType",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 291, col: 20, offset: 6934},
+							pos:        position{line: 293, col: 20, offset: 7085},
 							val:        "map",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 291, col: 26, offset: 6940},
+							pos:  position{line: 293, col: 26, offset: 7091},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 291, col: 29, offset: 6943},
+							pos:        position{line: 293, col: 29, offset: 7094},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 291, col: 33, offset: 6947},
+							pos:  position{line: 293, col: 33, offset: 7098},
 							name: "WS",
 						},
 						&labeledExpr{
-							pos:   position{line: 291, col: 36, offset: 6950},
+							pos:   position{line: 293, col: 36, offset: 7101},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 291, col: 40, offset: 6954},
+								pos:  position{line: 293, col: 40, offset: 7105},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 291, col: 50, offset: 6964},
+							pos:  position{line: 293, col: 50, offset: 7115},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 291, col: 53, offset: 6967},
+							pos:        position{line: 293, col: 53, offset: 7118},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 291, col: 57, offset: 6971},
+							pos:  position{line: 293, col: 57, offset: 7122},
 							name: "WS",
 						},
 						&labeledExpr{
-							pos:   position{line: 291, col: 60, offset: 6974},
+							pos:   position{line: 293, col: 60, offset: 7125},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 291, col: 66, offset: 6980},
+								pos:  position{line: 293, col: 66, offset: 7131},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 291, col: 76, offset: 6990},
+							pos:  position{line: 293, col: 76, offset: 7141},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 291, col: 79, offset: 6993},
+							pos:        position{line: 293, col: 79, offset: 7144},
 							val:        ">",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 291, col: 83, offset: 6997},
+							pos:  position{line: 293, col: 83, offset: 7148},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 291, col: 86, offset: 7000},
+							pos:   position{line: 293, col: 86, offset: 7151},
 							label: "annotations",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 291, col: 98, offset: 7012},
+								pos: position{line: 293, col: 98, offset: 7163},
 								expr: &ruleRefExpr{
-									pos:  position{line: 291, col: 98, offset: 7012},
+									pos:  position{line: 293, col: 98, offset: 7163},
 									name: "TypeAnnotations",
 								},
 							},
@@ -1415,66 +1445,66 @@ var g = &grammar{
 		},
 		{
 			name: "SetType",
-			pos:  position{line: 300, col: 1, offset: 7167},
+			pos:  position{line: 302, col: 1, offset: 7318},
 			expr: &actionExpr{
-				pos: position{line: 300, col: 11, offset: 7179},
+				pos: position{line: 302, col: 11, offset: 7330},
 				run: (*parser).callonSetType1,
 				expr: &seqExpr{
-					pos: position{line: 300, col: 11, offset: 7179},
+					pos: position{line: 302, col: 11, offset: 7330},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 300, col: 11, offset: 7179},
+							pos: position{line: 302, col: 11, offset: 7330},
 							expr: &ruleRefExpr{
-								pos:  position{line: 300, col: 11, offset: 7179},
+								pos:  position{line: 302, col: 11, offset: 7330},
 								name: "CppType",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 300, col: 20, offset: 7188},
+							pos:        position{line: 302, col: 20, offset: 7339},
 							val:        "set",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 300, col: 26, offset: 7194},
+							pos:  position{line: 302, col: 26, offset: 7345},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 300, col: 29, offset: 7197},
+							pos:        position{line: 302, col: 29, offset: 7348},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 300, col: 33, offset: 7201},
+							pos:  position{line: 302, col: 33, offset: 7352},
 							name: "WS",
 						},
 						&labeledExpr{
-							pos:   position{line: 300, col: 36, offset: 7204},
+							pos:   position{line: 302, col: 36, offset: 7355},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 300, col: 40, offset: 7208},
+								pos:  position{line: 302, col: 40, offset: 7359},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 300, col: 50, offset: 7218},
+							pos:  position{line: 302, col: 50, offset: 7369},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 300, col: 53, offset: 7221},
+							pos:        position{line: 302, col: 53, offset: 7372},
 							val:        ">",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 300, col: 57, offset: 7225},
+							pos:  position{line: 302, col: 57, offset: 7376},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 300, col: 60, offset: 7228},
+							pos:   position{line: 302, col: 60, offset: 7379},
 							label: "annotations",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 300, col: 72, offset: 7240},
+								pos: position{line: 302, col: 72, offset: 7391},
 								expr: &ruleRefExpr{
-									pos:  position{line: 300, col: 72, offset: 7240},
+									pos:  position{line: 302, col: 72, offset: 7391},
 									name: "TypeAnnotations",
 								},
 							},
@@ -1485,59 +1515,59 @@ var g = &grammar{
 		},
 		{
 			name: "ListType",
-			pos:  position{line: 308, col: 1, offset: 7369},
+			pos:  position{line: 310, col: 1, offset: 7520},
 			expr: &actionExpr{
-				pos: position{line: 308, col: 12, offset: 7382},
+				pos: position{line: 310, col: 12, offset: 7533},
 				run: (*parser).callonListType1,
 				expr: &seqExpr{
-					pos: position{line: 308, col: 12, offset: 7382},
+					pos: position{line: 310, col: 12, offset: 7533},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 308, col: 12, offset: 7382},
+							pos:        position{line: 310, col: 12, offset: 7533},
 							val:        "list",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 308, col: 19, offset: 7389},
+							pos:  position{line: 310, col: 19, offset: 7540},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 308, col: 22, offset: 7392},
+							pos:        position{line: 310, col: 22, offset: 7543},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 308, col: 26, offset: 7396},
+							pos:  position{line: 310, col: 26, offset: 7547},
 							name: "WS",
 						},
 						&labeledExpr{
-							pos:   position{line: 308, col: 29, offset: 7399},
+							pos:   position{line: 310, col: 29, offset: 7550},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 308, col: 33, offset: 7403},
+								pos:  position{line: 310, col: 33, offset: 7554},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 308, col: 43, offset: 7413},
+							pos:  position{line: 310, col: 43, offset: 7564},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 308, col: 46, offset: 7416},
+							pos:        position{line: 310, col: 46, offset: 7567},
 							val:        ">",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 308, col: 50, offset: 7420},
+							pos:  position{line: 310, col: 50, offset: 7571},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 308, col: 53, offset: 7423},
+							pos:   position{line: 310, col: 53, offset: 7574},
 							label: "annotations",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 308, col: 65, offset: 7435},
+								pos: position{line: 310, col: 65, offset: 7586},
 								expr: &ruleRefExpr{
-									pos:  position{line: 308, col: 65, offset: 7435},
+									pos:  position{line: 310, col: 65, offset: 7586},
 									name: "TypeAnnotations",
 								},
 							},
@@ -1548,23 +1578,23 @@ var g = &grammar{
 		},
 		{
 			name: "CppType",
-			pos:  position{line: 316, col: 1, offset: 7565},
+			pos:  position{line: 318, col: 1, offset: 7716},
 			expr: &actionExpr{
-				pos: position{line: 316, col: 11, offset: 7577},
+				pos: position{line: 318, col: 11, offset: 7728},
 				run: (*parser).callonCppType1,
 				expr: &seqExpr{
-					pos: position{line: 316, col: 11, offset: 7577},
+					pos: position{line: 318, col: 11, offset: 7728},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 316, col: 11, offset: 7577},
+							pos:        position{line: 318, col: 11, offset: 7728},
 							val:        "cpp_type",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 316, col: 22, offset: 7588},
+							pos:   position{line: 318, col: 22, offset: 7739},
 							label: "cppType",
 							expr: &ruleRefExpr{
-								pos:  position{line: 316, col: 30, offset: 7596},
+								pos:  position{line: 318, col: 30, offset: 7747},
 								name: "Literal",
 							},
 						},
@@ -1574,32 +1604,32 @@ var g = &grammar{
 		},
 		{
 			name: "ConstValue",
-			pos:  position{line: 320, col: 1, offset: 7630},
+			pos:  position{line: 322, col: 1, offset: 7781},
 			expr: &choiceExpr{
-				pos: position{line: 320, col: 14, offset: 7645},
+				pos: position{line: 322, col: 14, offset: 7796},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 320, col: 14, offset: 7645},
+						pos:  position{line: 322, col: 14, offset: 7796},
 						name: "Literal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 320, col: 24, offset: 7655},
+						pos:  position{line: 322, col: 24, offset: 7806},
 						name: "DoubleConstant",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 320, col: 41, offset: 7672},
+						pos:  position{line: 322, col: 41, offset: 7823},
 						name: "IntConstant",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 320, col: 55, offset: 7686},
+						pos:  position{line: 322, col: 55, offset: 7837},
 						name: "ConstMap",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 320, col: 66, offset: 7697},
+						pos:  position{line: 322, col: 66, offset: 7848},
 						name: "ConstList",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 320, col: 78, offset: 7709},
+						pos:  position{line: 322, col: 78, offset: 7860},
 						name: "Identifier",
 					},
 				},
@@ -1607,35 +1637,35 @@ var g = &grammar{
 		},
 		{
 			name: "TypeAnnotations",
-			pos:  position{line: 322, col: 1, offset: 7721},
+			pos:  position{line: 324, col: 1, offset: 7872},
 			expr: &actionExpr{
-				pos: position{line: 322, col: 19, offset: 7741},
+				pos: position{line: 324, col: 19, offset: 7892},
 				run: (*parser).callonTypeAnnotations1,
 				expr: &seqExpr{
-					pos: position{line: 322, col: 19, offset: 7741},
+					pos: position{line: 324, col: 19, offset: 7892},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 322, col: 19, offset: 7741},
+							pos:        position{line: 324, col: 19, offset: 7892},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 322, col: 23, offset: 7745},
+							pos:  position{line: 324, col: 23, offset: 7896},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 322, col: 26, offset: 7748},
+							pos:   position{line: 324, col: 26, offset: 7899},
 							label: "annotations",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 322, col: 38, offset: 7760},
+								pos: position{line: 324, col: 38, offset: 7911},
 								expr: &ruleRefExpr{
-									pos:  position{line: 322, col: 38, offset: 7760},
+									pos:  position{line: 324, col: 38, offset: 7911},
 									name: "TypeAnnotation",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 322, col: 54, offset: 7776},
+							pos:        position{line: 324, col: 54, offset: 7927},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -1645,50 +1675,50 @@ var g = &grammar{
 		},
 		{
 			name: "TypeAnnotation",
-			pos:  position{line: 330, col: 1, offset: 7922},
+			pos:  position{line: 332, col: 1, offset: 8073},
 			expr: &actionExpr{
-				pos: position{line: 330, col: 18, offset: 7941},
+				pos: position{line: 332, col: 18, offset: 8092},
 				run: (*parser).callonTypeAnnotation1,
 				expr: &seqExpr{
-					pos: position{line: 330, col: 18, offset: 7941},
+					pos: position{line: 332, col: 18, offset: 8092},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 330, col: 18, offset: 7941},
+							pos:   position{line: 332, col: 18, offset: 8092},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 330, col: 23, offset: 7946},
+								pos:  position{line: 332, col: 23, offset: 8097},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 330, col: 34, offset: 7957},
+							pos:  position{line: 332, col: 34, offset: 8108},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 330, col: 36, offset: 7959},
+							pos:   position{line: 332, col: 36, offset: 8110},
 							label: "value",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 330, col: 42, offset: 7965},
+								pos: position{line: 332, col: 42, offset: 8116},
 								expr: &actionExpr{
-									pos: position{line: 330, col: 43, offset: 7966},
+									pos: position{line: 332, col: 43, offset: 8117},
 									run: (*parser).callonTypeAnnotation8,
 									expr: &seqExpr{
-										pos: position{line: 330, col: 43, offset: 7966},
+										pos: position{line: 332, col: 43, offset: 8117},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 330, col: 43, offset: 7966},
+												pos:        position{line: 332, col: 43, offset: 8117},
 												val:        "=",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 330, col: 47, offset: 7970},
+												pos:  position{line: 332, col: 47, offset: 8121},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 330, col: 50, offset: 7973},
+												pos:   position{line: 332, col: 50, offset: 8124},
 												label: "value",
 												expr: &ruleRefExpr{
-													pos:  position{line: 330, col: 56, offset: 7979},
+													pos:  position{line: 332, col: 56, offset: 8130},
 													name: "Literal",
 												},
 											},
@@ -1698,14 +1728,14 @@ var g = &grammar{
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 330, col: 88, offset: 8011},
+							pos: position{line: 332, col: 88, offset: 8162},
 							expr: &ruleRefExpr{
-								pos:  position{line: 330, col: 88, offset: 8011},
+								pos:  position{line: 332, col: 88, offset: 8162},
 								name: "ListSeparator",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 330, col: 103, offset: 8026},
+							pos:  position{line: 332, col: 103, offset: 8177},
 							name: "__",
 						},
 					},
@@ -1714,17 +1744,17 @@ var g = &grammar{
 		},
 		{
 			name: "IntConstant",
-			pos:  position{line: 341, col: 1, offset: 8189},
+			pos:  position{line: 343, col: 1, offset: 8340},
 			expr: &actionExpr{
-				pos: position{line: 341, col: 15, offset: 8205},
+				pos: position{line: 343, col: 15, offset: 8356},
 				run: (*parser).callonIntConstant1,
 				expr: &seqExpr{
-					pos: position{line: 341, col: 15, offset: 8205},
+					pos: position{line: 343, col: 15, offset: 8356},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 341, col: 15, offset: 8205},
+							pos: position{line: 343, col: 15, offset: 8356},
 							expr: &charClassMatcher{
-								pos:        position{line: 341, col: 15, offset: 8205},
+								pos:        position{line: 343, col: 15, offset: 8356},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -1732,9 +1762,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 341, col: 21, offset: 8211},
+							pos: position{line: 343, col: 21, offset: 8362},
 							expr: &ruleRefExpr{
-								pos:  position{line: 341, col: 21, offset: 8211},
+								pos:  position{line: 343, col: 21, offset: 8362},
 								name: "Digit",
 							},
 						},
@@ -1744,17 +1774,17 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleConstant",
-			pos:  position{line: 345, col: 1, offset: 8272},
+			pos:  position{line: 347, col: 1, offset: 8423},
 			expr: &actionExpr{
-				pos: position{line: 345, col: 18, offset: 8291},
+				pos: position{line: 347, col: 18, offset: 8442},
 				run: (*parser).callonDoubleConstant1,
 				expr: &seqExpr{
-					pos: position{line: 345, col: 18, offset: 8291},
+					pos: position{line: 347, col: 18, offset: 8442},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 345, col: 18, offset: 8291},
+							pos: position{line: 347, col: 18, offset: 8442},
 							expr: &charClassMatcher{
-								pos:        position{line: 345, col: 18, offset: 8291},
+								pos:        position{line: 347, col: 18, offset: 8442},
 								val:        "[+-]",
 								chars:      []rune{'+', '-'},
 								ignoreCase: false,
@@ -1762,38 +1792,38 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 345, col: 24, offset: 8297},
+							pos: position{line: 347, col: 24, offset: 8448},
 							expr: &ruleRefExpr{
-								pos:  position{line: 345, col: 24, offset: 8297},
+								pos:  position{line: 347, col: 24, offset: 8448},
 								name: "Digit",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 345, col: 31, offset: 8304},
+							pos:        position{line: 347, col: 31, offset: 8455},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 345, col: 35, offset: 8308},
+							pos: position{line: 347, col: 35, offset: 8459},
 							expr: &ruleRefExpr{
-								pos:  position{line: 345, col: 35, offset: 8308},
+								pos:  position{line: 347, col: 35, offset: 8459},
 								name: "Digit",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 345, col: 42, offset: 8315},
+							pos: position{line: 347, col: 42, offset: 8466},
 							expr: &seqExpr{
-								pos: position{line: 345, col: 44, offset: 8317},
+								pos: position{line: 347, col: 44, offset: 8468},
 								exprs: []interface{}{
 									&charClassMatcher{
-										pos:        position{line: 345, col: 44, offset: 8317},
+										pos:        position{line: 347, col: 44, offset: 8468},
 										val:        "['Ee']",
 										chars:      []rune{'\'', 'E', 'e', '\''},
 										ignoreCase: false,
 										inverted:   false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 345, col: 51, offset: 8324},
+										pos:  position{line: 347, col: 51, offset: 8475},
 										name: "IntConstant",
 									},
 								},
@@ -1805,47 +1835,47 @@ var g = &grammar{
 		},
 		{
 			name: "ConstList",
-			pos:  position{line: 349, col: 1, offset: 8391},
+			pos:  position{line: 351, col: 1, offset: 8542},
 			expr: &actionExpr{
-				pos: position{line: 349, col: 13, offset: 8405},
+				pos: position{line: 351, col: 13, offset: 8556},
 				run: (*parser).callonConstList1,
 				expr: &seqExpr{
-					pos: position{line: 349, col: 13, offset: 8405},
+					pos: position{line: 351, col: 13, offset: 8556},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 349, col: 13, offset: 8405},
+							pos:        position{line: 351, col: 13, offset: 8556},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 349, col: 17, offset: 8409},
+							pos:  position{line: 351, col: 17, offset: 8560},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 349, col: 20, offset: 8412},
+							pos:   position{line: 351, col: 20, offset: 8563},
 							label: "values",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 349, col: 27, offset: 8419},
+								pos: position{line: 351, col: 27, offset: 8570},
 								expr: &seqExpr{
-									pos: position{line: 349, col: 28, offset: 8420},
+									pos: position{line: 351, col: 28, offset: 8571},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 349, col: 28, offset: 8420},
+											pos:  position{line: 351, col: 28, offset: 8571},
 											name: "ConstValue",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 349, col: 39, offset: 8431},
+											pos:  position{line: 351, col: 39, offset: 8582},
 											name: "__",
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 349, col: 42, offset: 8434},
+											pos: position{line: 351, col: 42, offset: 8585},
 											expr: &ruleRefExpr{
-												pos:  position{line: 349, col: 42, offset: 8434},
+												pos:  position{line: 351, col: 42, offset: 8585},
 												name: "ListSeparator",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 349, col: 57, offset: 8449},
+											pos:  position{line: 351, col: 57, offset: 8600},
 											name: "__",
 										},
 									},
@@ -1853,11 +1883,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 349, col: 62, offset: 8454},
+							pos:  position{line: 351, col: 62, offset: 8605},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 349, col: 65, offset: 8457},
+							pos:        position{line: 351, col: 65, offset: 8608},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -1867,67 +1897,67 @@ var g = &grammar{
 		},
 		{
 			name: "ConstMap",
-			pos:  position{line: 358, col: 1, offset: 8630},
+			pos:  position{line: 360, col: 1, offset: 8781},
 			expr: &actionExpr{
-				pos: position{line: 358, col: 12, offset: 8643},
+				pos: position{line: 360, col: 12, offset: 8794},
 				run: (*parser).callonConstMap1,
 				expr: &seqExpr{
-					pos: position{line: 358, col: 12, offset: 8643},
+					pos: position{line: 360, col: 12, offset: 8794},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 358, col: 12, offset: 8643},
+							pos:        position{line: 360, col: 12, offset: 8794},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 358, col: 16, offset: 8647},
+							pos:  position{line: 360, col: 16, offset: 8798},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 358, col: 19, offset: 8650},
+							pos:   position{line: 360, col: 19, offset: 8801},
 							label: "values",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 358, col: 26, offset: 8657},
+								pos: position{line: 360, col: 26, offset: 8808},
 								expr: &seqExpr{
-									pos: position{line: 358, col: 27, offset: 8658},
+									pos: position{line: 360, col: 27, offset: 8809},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 358, col: 27, offset: 8658},
+											pos:  position{line: 360, col: 27, offset: 8809},
 											name: "ConstValue",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 358, col: 38, offset: 8669},
+											pos:  position{line: 360, col: 38, offset: 8820},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 358, col: 41, offset: 8672},
+											pos:        position{line: 360, col: 41, offset: 8823},
 											val:        ":",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 358, col: 45, offset: 8676},
+											pos:  position{line: 360, col: 45, offset: 8827},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 358, col: 48, offset: 8679},
+											pos:  position{line: 360, col: 48, offset: 8830},
 											name: "ConstValue",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 358, col: 59, offset: 8690},
+											pos:  position{line: 360, col: 59, offset: 8841},
 											name: "__",
 										},
 										&choiceExpr{
-											pos: position{line: 358, col: 63, offset: 8694},
+											pos: position{line: 360, col: 63, offset: 8845},
 											alternatives: []interface{}{
 												&litMatcher{
-													pos:        position{line: 358, col: 63, offset: 8694},
+													pos:        position{line: 360, col: 63, offset: 8845},
 													val:        ",",
 													ignoreCase: false,
 												},
 												&andExpr{
-													pos: position{line: 358, col: 69, offset: 8700},
+													pos: position{line: 360, col: 69, offset: 8851},
 													expr: &litMatcher{
-														pos:        position{line: 358, col: 70, offset: 8701},
+														pos:        position{line: 360, col: 70, offset: 8852},
 														val:        "}",
 														ignoreCase: false,
 													},
@@ -1935,7 +1965,7 @@ var g = &grammar{
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 358, col: 75, offset: 8706},
+											pos:  position{line: 360, col: 75, offset: 8857},
 											name: "__",
 										},
 									},
@@ -1943,7 +1973,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 358, col: 80, offset: 8711},
+							pos:        position{line: 360, col: 80, offset: 8862},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -1953,33 +1983,33 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 374, col: 1, offset: 8957},
+			pos:  position{line: 376, col: 1, offset: 9108},
 			expr: &actionExpr{
-				pos: position{line: 374, col: 11, offset: 8969},
+				pos: position{line: 376, col: 11, offset: 9120},
 				run: (*parser).callonLiteral1,
 				expr: &choiceExpr{
-					pos: position{line: 374, col: 12, offset: 8970},
+					pos: position{line: 376, col: 12, offset: 9121},
 					alternatives: []interface{}{
 						&seqExpr{
-							pos: position{line: 374, col: 13, offset: 8971},
+							pos: position{line: 376, col: 13, offset: 9122},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 374, col: 13, offset: 8971},
+									pos:        position{line: 376, col: 13, offset: 9122},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 374, col: 17, offset: 8975},
+									pos: position{line: 376, col: 17, offset: 9126},
 									expr: &choiceExpr{
-										pos: position{line: 374, col: 18, offset: 8976},
+										pos: position{line: 376, col: 18, offset: 9127},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 374, col: 18, offset: 8976},
+												pos:        position{line: 376, col: 18, offset: 9127},
 												val:        "\\\"",
 												ignoreCase: false,
 											},
 											&charClassMatcher{
-												pos:        position{line: 374, col: 25, offset: 8983},
+												pos:        position{line: 376, col: 25, offset: 9134},
 												val:        "[^\"]",
 												chars:      []rune{'"'},
 												ignoreCase: false,
@@ -1989,32 +2019,32 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 374, col: 32, offset: 8990},
+									pos:        position{line: 376, col: 32, offset: 9141},
 									val:        "\"",
 									ignoreCase: false,
 								},
 							},
 						},
 						&seqExpr{
-							pos: position{line: 374, col: 40, offset: 8998},
+							pos: position{line: 376, col: 40, offset: 9149},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 374, col: 40, offset: 8998},
+									pos:        position{line: 376, col: 40, offset: 9149},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 374, col: 45, offset: 9003},
+									pos: position{line: 376, col: 45, offset: 9154},
 									expr: &choiceExpr{
-										pos: position{line: 374, col: 46, offset: 9004},
+										pos: position{line: 376, col: 46, offset: 9155},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 374, col: 46, offset: 9004},
+												pos:        position{line: 376, col: 46, offset: 9155},
 												val:        "\\'",
 												ignoreCase: false,
 											},
 											&charClassMatcher{
-												pos:        position{line: 374, col: 53, offset: 9011},
+												pos:        position{line: 376, col: 53, offset: 9162},
 												val:        "[^']",
 												chars:      []rune{'\''},
 												ignoreCase: false,
@@ -2024,7 +2054,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 374, col: 60, offset: 9018},
+									pos:        position{line: 376, col: 60, offset: 9169},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -2036,24 +2066,24 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 381, col: 1, offset: 9219},
+			pos:  position{line: 383, col: 1, offset: 9370},
 			expr: &actionExpr{
-				pos: position{line: 381, col: 14, offset: 9234},
+				pos: position{line: 383, col: 14, offset: 9385},
 				run: (*parser).callonIdentifier1,
 				expr: &seqExpr{
-					pos: position{line: 381, col: 14, offset: 9234},
+					pos: position{line: 383, col: 14, offset: 9385},
 					exprs: []interface{}{
 						&oneOrMoreExpr{
-							pos: position{line: 381, col: 14, offset: 9234},
+							pos: position{line: 383, col: 14, offset: 9385},
 							expr: &choiceExpr{
-								pos: position{line: 381, col: 15, offset: 9235},
+								pos: position{line: 383, col: 15, offset: 9386},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 381, col: 15, offset: 9235},
+										pos:  position{line: 383, col: 15, offset: 9386},
 										name: "Letter",
 									},
 									&litMatcher{
-										pos:        position{line: 381, col: 24, offset: 9244},
+										pos:        position{line: 383, col: 24, offset: 9395},
 										val:        "_",
 										ignoreCase: false,
 									},
@@ -2061,20 +2091,20 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 381, col: 30, offset: 9250},
+							pos: position{line: 383, col: 30, offset: 9401},
 							expr: &choiceExpr{
-								pos: position{line: 381, col: 31, offset: 9251},
+								pos: position{line: 383, col: 31, offset: 9402},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 381, col: 31, offset: 9251},
+										pos:  position{line: 383, col: 31, offset: 9402},
 										name: "Letter",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 381, col: 40, offset: 9260},
+										pos:  position{line: 383, col: 40, offset: 9411},
 										name: "Digit",
 									},
 									&charClassMatcher{
-										pos:        position{line: 381, col: 48, offset: 9268},
+										pos:        position{line: 383, col: 48, offset: 9419},
 										val:        "[._]",
 										chars:      []rune{'.', '_'},
 										ignoreCase: false,
@@ -2089,9 +2119,9 @@ var g = &grammar{
 		},
 		{
 			name: "ListSeparator",
-			pos:  position{line: 385, col: 1, offset: 9320},
+			pos:  position{line: 387, col: 1, offset: 9471},
 			expr: &charClassMatcher{
-				pos:        position{line: 385, col: 17, offset: 9338},
+				pos:        position{line: 387, col: 17, offset: 9489},
 				val:        "[,;]",
 				chars:      []rune{',', ';'},
 				ignoreCase: false,
@@ -2100,9 +2130,9 @@ var g = &grammar{
 		},
 		{
 			name: "Letter",
-			pos:  position{line: 386, col: 1, offset: 9343},
+			pos:  position{line: 388, col: 1, offset: 9494},
 			expr: &charClassMatcher{
-				pos:        position{line: 386, col: 10, offset: 9354},
+				pos:        position{line: 388, col: 10, offset: 9505},
 				val:        "[A-Za-z]",
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
 				ignoreCase: false,
@@ -2111,9 +2141,9 @@ var g = &grammar{
 		},
 		{
 			name: "Digit",
-			pos:  position{line: 387, col: 1, offset: 9363},
+			pos:  position{line: 389, col: 1, offset: 9514},
 			expr: &charClassMatcher{
-				pos:        position{line: 387, col: 9, offset: 9373},
+				pos:        position{line: 389, col: 9, offset: 9524},
 				val:        "[0-9]",
 				ranges:     []rune{'0', '9'},
 				ignoreCase: false,
@@ -2122,23 +2152,23 @@ var g = &grammar{
 		},
 		{
 			name: "SourceChar",
-			pos:  position{line: 391, col: 1, offset: 9384},
+			pos:  position{line: 393, col: 1, offset: 9535},
 			expr: &anyMatcher{
-				line: 391, col: 14, offset: 9399,
+				line: 393, col: 14, offset: 9550,
 			},
 		},
 		{
 			name: "Comment",
-			pos:  position{line: 392, col: 1, offset: 9401},
+			pos:  position{line: 394, col: 1, offset: 9552},
 			expr: &choiceExpr{
-				pos: position{line: 392, col: 11, offset: 9413},
+				pos: position{line: 394, col: 11, offset: 9564},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 392, col: 11, offset: 9413},
+						pos:  position{line: 394, col: 11, offset: 9564},
 						name: "MultiLineComment",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 392, col: 30, offset: 9432},
+						pos:  position{line: 394, col: 30, offset: 9583},
 						name: "SingleLineComment",
 					},
 				},
@@ -2146,37 +2176,37 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 393, col: 1, offset: 9450},
+			pos:  position{line: 395, col: 1, offset: 9601},
 			expr: &seqExpr{
-				pos: position{line: 393, col: 20, offset: 9471},
+				pos: position{line: 395, col: 20, offset: 9622},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 393, col: 20, offset: 9471},
+						pos:        position{line: 395, col: 20, offset: 9622},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 393, col: 25, offset: 9476},
+						pos: position{line: 395, col: 25, offset: 9627},
 						expr: &seqExpr{
-							pos: position{line: 393, col: 27, offset: 9478},
+							pos: position{line: 395, col: 27, offset: 9629},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 393, col: 27, offset: 9478},
+									pos: position{line: 395, col: 27, offset: 9629},
 									expr: &litMatcher{
-										pos:        position{line: 393, col: 28, offset: 9479},
+										pos:        position{line: 395, col: 28, offset: 9630},
 										val:        "*/",
 										ignoreCase: false,
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 393, col: 33, offset: 9484},
+									pos:  position{line: 395, col: 33, offset: 9635},
 									name: "SourceChar",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 393, col: 47, offset: 9498},
+						pos:        position{line: 395, col: 47, offset: 9649},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -2185,46 +2215,46 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineCommentNoLineTerminator",
-			pos:  position{line: 394, col: 1, offset: 9503},
+			pos:  position{line: 396, col: 1, offset: 9654},
 			expr: &seqExpr{
-				pos: position{line: 394, col: 36, offset: 9540},
+				pos: position{line: 396, col: 36, offset: 9691},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 394, col: 36, offset: 9540},
+						pos:        position{line: 396, col: 36, offset: 9691},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 394, col: 41, offset: 9545},
+						pos: position{line: 396, col: 41, offset: 9696},
 						expr: &seqExpr{
-							pos: position{line: 394, col: 43, offset: 9547},
+							pos: position{line: 396, col: 43, offset: 9698},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 394, col: 43, offset: 9547},
+									pos: position{line: 396, col: 43, offset: 9698},
 									expr: &choiceExpr{
-										pos: position{line: 394, col: 46, offset: 9550},
+										pos: position{line: 396, col: 46, offset: 9701},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 394, col: 46, offset: 9550},
+												pos:        position{line: 396, col: 46, offset: 9701},
 												val:        "*/",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 394, col: 53, offset: 9557},
+												pos:  position{line: 396, col: 53, offset: 9708},
 												name: "EOL",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 394, col: 59, offset: 9563},
+									pos:  position{line: 396, col: 59, offset: 9714},
 									name: "SourceChar",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 394, col: 73, offset: 9577},
+						pos:        position{line: 396, col: 73, offset: 9728},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -2233,32 +2263,32 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 395, col: 1, offset: 9582},
+			pos:  position{line: 397, col: 1, offset: 9733},
 			expr: &choiceExpr{
-				pos: position{line: 395, col: 21, offset: 9604},
+				pos: position{line: 397, col: 21, offset: 9755},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 395, col: 22, offset: 9605},
+						pos: position{line: 397, col: 22, offset: 9756},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 395, col: 22, offset: 9605},
+								pos:        position{line: 397, col: 22, offset: 9756},
 								val:        "//",
 								ignoreCase: false,
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 395, col: 27, offset: 9610},
+								pos: position{line: 397, col: 27, offset: 9761},
 								expr: &seqExpr{
-									pos: position{line: 395, col: 29, offset: 9612},
+									pos: position{line: 397, col: 29, offset: 9763},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 395, col: 29, offset: 9612},
+											pos: position{line: 397, col: 29, offset: 9763},
 											expr: &ruleRefExpr{
-												pos:  position{line: 395, col: 30, offset: 9613},
+												pos:  position{line: 397, col: 30, offset: 9764},
 												name: "EOL",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 395, col: 34, offset: 9617},
+											pos:  position{line: 397, col: 34, offset: 9768},
 											name: "SourceChar",
 										},
 									},
@@ -2267,27 +2297,27 @@ var g = &grammar{
 						},
 					},
 					&seqExpr{
-						pos: position{line: 395, col: 52, offset: 9635},
+						pos: position{line: 397, col: 52, offset: 9786},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 395, col: 52, offset: 9635},
+								pos:        position{line: 397, col: 52, offset: 9786},
 								val:        "#",
 								ignoreCase: false,
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 395, col: 56, offset: 9639},
+								pos: position{line: 397, col: 56, offset: 9790},
 								expr: &seqExpr{
-									pos: position{line: 395, col: 58, offset: 9641},
+									pos: position{line: 397, col: 58, offset: 9792},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 395, col: 58, offset: 9641},
+											pos: position{line: 397, col: 58, offset: 9792},
 											expr: &ruleRefExpr{
-												pos:  position{line: 395, col: 59, offset: 9642},
+												pos:  position{line: 397, col: 59, offset: 9793},
 												name: "EOL",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 395, col: 63, offset: 9646},
+											pos:  position{line: 397, col: 63, offset: 9797},
 											name: "SourceChar",
 										},
 									},
@@ -2300,22 +2330,22 @@ var g = &grammar{
 		},
 		{
 			name: "__",
-			pos:  position{line: 397, col: 1, offset: 9662},
+			pos:  position{line: 399, col: 1, offset: 9813},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 397, col: 6, offset: 9669},
+				pos: position{line: 399, col: 6, offset: 9820},
 				expr: &choiceExpr{
-					pos: position{line: 397, col: 8, offset: 9671},
+					pos: position{line: 399, col: 8, offset: 9822},
 					alternatives: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 397, col: 8, offset: 9671},
+							pos:  position{line: 399, col: 8, offset: 9822},
 							name: "Whitespace",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 397, col: 21, offset: 9684},
+							pos:  position{line: 399, col: 21, offset: 9835},
 							name: "EOL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 397, col: 27, offset: 9690},
+							pos:  position{line: 399, col: 27, offset: 9841},
 							name: "Comment",
 						},
 					},
@@ -2324,18 +2354,18 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 398, col: 1, offset: 9701},
+			pos:  position{line: 400, col: 1, offset: 9852},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 398, col: 5, offset: 9707},
+				pos: position{line: 400, col: 5, offset: 9858},
 				expr: &choiceExpr{
-					pos: position{line: 398, col: 7, offset: 9709},
+					pos: position{line: 400, col: 7, offset: 9860},
 					alternatives: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 398, col: 7, offset: 9709},
+							pos:  position{line: 400, col: 7, offset: 9860},
 							name: "Whitespace",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 398, col: 20, offset: 9722},
+							pos:  position{line: 400, col: 20, offset: 9873},
 							name: "MultiLineCommentNoLineTerminator",
 						},
 					},
@@ -2344,20 +2374,20 @@ var g = &grammar{
 		},
 		{
 			name: "WS",
-			pos:  position{line: 399, col: 1, offset: 9758},
+			pos:  position{line: 401, col: 1, offset: 9909},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 399, col: 6, offset: 9765},
+				pos: position{line: 401, col: 6, offset: 9916},
 				expr: &ruleRefExpr{
-					pos:  position{line: 399, col: 6, offset: 9765},
+					pos:  position{line: 401, col: 6, offset: 9916},
 					name: "Whitespace",
 				},
 			},
 		},
 		{
 			name: "Whitespace",
-			pos:  position{line: 401, col: 1, offset: 9778},
+			pos:  position{line: 403, col: 1, offset: 9929},
 			expr: &charClassMatcher{
-				pos:        position{line: 401, col: 14, offset: 9793},
+				pos:        position{line: 403, col: 14, offset: 9944},
 				val:        "[ \\t\\r]",
 				chars:      []rune{' ', '\t', '\r'},
 				ignoreCase: false,
@@ -2366,62 +2396,62 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 402, col: 1, offset: 9801},
+			pos:  position{line: 404, col: 1, offset: 9952},
 			expr: &litMatcher{
-				pos:        position{line: 402, col: 7, offset: 9809},
+				pos:        position{line: 404, col: 7, offset: 9960},
 				val:        "\n",
 				ignoreCase: false,
 			},
 		},
 		{
 			name: "EOS",
-			pos:  position{line: 403, col: 1, offset: 9814},
+			pos:  position{line: 405, col: 1, offset: 9965},
 			expr: &choiceExpr{
-				pos: position{line: 403, col: 7, offset: 9822},
+				pos: position{line: 405, col: 7, offset: 9973},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 403, col: 7, offset: 9822},
+						pos: position{line: 405, col: 7, offset: 9973},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 403, col: 7, offset: 9822},
+								pos:  position{line: 405, col: 7, offset: 9973},
 								name: "__",
 							},
 							&litMatcher{
-								pos:        position{line: 403, col: 10, offset: 9825},
+								pos:        position{line: 405, col: 10, offset: 9976},
 								val:        ";",
 								ignoreCase: false,
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 403, col: 16, offset: 9831},
+						pos: position{line: 405, col: 16, offset: 9982},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 403, col: 16, offset: 9831},
+								pos:  position{line: 405, col: 16, offset: 9982},
 								name: "_",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 403, col: 18, offset: 9833},
+								pos: position{line: 405, col: 18, offset: 9984},
 								expr: &ruleRefExpr{
-									pos:  position{line: 403, col: 18, offset: 9833},
+									pos:  position{line: 405, col: 18, offset: 9984},
 									name: "SingleLineComment",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 403, col: 37, offset: 9852},
+								pos:  position{line: 405, col: 37, offset: 10003},
 								name: "EOL",
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 403, col: 43, offset: 9858},
+						pos: position{line: 405, col: 43, offset: 10009},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 403, col: 43, offset: 9858},
+								pos:  position{line: 405, col: 43, offset: 10009},
 								name: "__",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 403, col: 46, offset: 9861},
+								pos:  position{line: 405, col: 46, offset: 10012},
 								name: "EOF",
 							},
 						},
@@ -2431,11 +2461,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 405, col: 1, offset: 9866},
+			pos:  position{line: 407, col: 1, offset: 10017},
 			expr: &notExpr{
-				pos: position{line: 405, col: 7, offset: 9874},
+				pos: position{line: 407, col: 7, offset: 10025},
 				expr: &anyMatcher{
-					line: 405, col: 8, offset: 9875,
+					line: 407, col: 8, offset: 10026,
 				},
 			},
 		},
@@ -2695,11 +2725,12 @@ func (p *parser) callonFieldReq1() (interface{}, error) {
 	return p.cur.onFieldReq1()
 }
 
-func (c *current) onService1(name, extends, methods interface{}) (interface{}, error) {
+func (c *current) onService1(name, extends, methods, annotations interface{}) (interface{}, error) {
 	ms := methods.([]interface{})
 	svc := &Service{
-		Name:    string(name.(Identifier)),
-		Methods: make(map[string]*Method, len(ms)),
+		Name:        string(name.(Identifier)),
+		Methods:     make(map[string]*Method, len(ms)),
+		Annotations: toAnnotations(annotations),
 	}
 	if extends != nil {
 		svc.Extends = string(extends.([]interface{})[2].(Identifier))
@@ -2714,7 +2745,7 @@ func (c *current) onService1(name, extends, methods interface{}) (interface{}, e
 func (p *parser) callonService1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onService1(stack["name"], stack["extends"], stack["methods"])
+	return p.cur.onService1(stack["name"], stack["extends"], stack["methods"], stack["annotations"])
 }
 
 func (c *current) onEndOfServiceError1() (interface{}, error) {
@@ -2727,9 +2758,10 @@ func (p *parser) callonEndOfServiceError1() (interface{}, error) {
 	return p.cur.onEndOfServiceError1()
 }
 
-func (c *current) onFunction1(oneway, typ, name, arguments, exceptions interface{}) (interface{}, error) {
+func (c *current) onFunction1(oneway, typ, name, arguments, exceptions, annotations interface{}) (interface{}, error) {
 	m := &Method{
-		Name: string(name.(Identifier)),
+		Name:        string(name.(Identifier)),
+		Annotations: toAnnotations(annotations),
 	}
 	t := typ.(*Type)
 	if t.Name != "void" {
@@ -2753,7 +2785,7 @@ func (c *current) onFunction1(oneway, typ, name, arguments, exceptions interface
 func (p *parser) callonFunction1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onFunction1(stack["oneway"], stack["typ"], stack["name"], stack["arguments"], stack["exceptions"])
+	return p.cur.onFunction1(stack["oneway"], stack["typ"], stack["name"], stack["arguments"], stack["exceptions"], stack["annotations"])
 }
 
 func (c *current) onFunctionType1(typ interface{}) (interface{}, error) {

--- a/parser/grammar.peg.go
+++ b/parser/grammar.peg.go
@@ -819,10 +819,25 @@ var g = &grammar{
 								},
 							},
 						},
+						&ruleRefExpr{
+							pos:  position{line: 193, col: 107, offset: 4672},
+							name: "__",
+						},
+						&labeledExpr{
+							pos:   position{line: 193, col: 110, offset: 4675},
+							label: "annotations",
+							expr: &zeroOrOneExpr{
+								pos: position{line: 193, col: 122, offset: 4687},
+								expr: &ruleRefExpr{
+									pos:  position{line: 193, col: 122, offset: 4687},
+									name: "TypeAnnotations",
+								},
+							},
+						},
 						&zeroOrOneExpr{
-							pos: position{line: 193, col: 107, offset: 4672},
+							pos: position{line: 193, col: 139, offset: 4704},
 							expr: &ruleRefExpr{
-								pos:  position{line: 193, col: 107, offset: 4672},
+								pos:  position{line: 193, col: 139, offset: 4704},
 								name: "ListSeparator",
 							},
 						},
@@ -832,20 +847,20 @@ var g = &grammar{
 		},
 		{
 			name: "FieldReq",
-			pos:  position{line: 208, col: 1, offset: 4932},
+			pos:  position{line: 209, col: 1, offset: 5007},
 			expr: &actionExpr{
-				pos: position{line: 208, col: 12, offset: 4945},
+				pos: position{line: 209, col: 12, offset: 5020},
 				run: (*parser).callonFieldReq1,
 				expr: &choiceExpr{
-					pos: position{line: 208, col: 13, offset: 4946},
+					pos: position{line: 209, col: 13, offset: 5021},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 208, col: 13, offset: 4946},
+							pos:        position{line: 209, col: 13, offset: 5021},
 							val:        "required",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 208, col: 26, offset: 4959},
+							pos:        position{line: 209, col: 26, offset: 5034},
 							val:        "optional",
 							ignoreCase: false,
 						},
@@ -855,57 +870,57 @@ var g = &grammar{
 		},
 		{
 			name: "Service",
-			pos:  position{line: 212, col: 1, offset: 5030},
+			pos:  position{line: 213, col: 1, offset: 5105},
 			expr: &actionExpr{
-				pos: position{line: 212, col: 11, offset: 5042},
+				pos: position{line: 213, col: 11, offset: 5117},
 				run: (*parser).callonService1,
 				expr: &seqExpr{
-					pos: position{line: 212, col: 11, offset: 5042},
+					pos: position{line: 213, col: 11, offset: 5117},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 212, col: 11, offset: 5042},
+							pos:        position{line: 213, col: 11, offset: 5117},
 							val:        "service",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 212, col: 21, offset: 5052},
+							pos:  position{line: 213, col: 21, offset: 5127},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 212, col: 23, offset: 5054},
+							pos:   position{line: 213, col: 23, offset: 5129},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 212, col: 28, offset: 5059},
+								pos:  position{line: 213, col: 28, offset: 5134},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 212, col: 39, offset: 5070},
+							pos:  position{line: 213, col: 39, offset: 5145},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 212, col: 41, offset: 5072},
+							pos:   position{line: 213, col: 41, offset: 5147},
 							label: "extends",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 212, col: 49, offset: 5080},
+								pos: position{line: 213, col: 49, offset: 5155},
 								expr: &seqExpr{
-									pos: position{line: 212, col: 50, offset: 5081},
+									pos: position{line: 213, col: 50, offset: 5156},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 212, col: 50, offset: 5081},
+											pos:        position{line: 213, col: 50, offset: 5156},
 											val:        "extends",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 212, col: 60, offset: 5091},
+											pos:  position{line: 213, col: 60, offset: 5166},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 212, col: 63, offset: 5094},
+											pos:  position{line: 213, col: 63, offset: 5169},
 											name: "Identifier",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 212, col: 74, offset: 5105},
+											pos:  position{line: 213, col: 74, offset: 5180},
 											name: "__",
 										},
 									},
@@ -913,32 +928,32 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 212, col: 79, offset: 5110},
+							pos:  position{line: 213, col: 79, offset: 5185},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 212, col: 82, offset: 5113},
+							pos:        position{line: 213, col: 82, offset: 5188},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 212, col: 86, offset: 5117},
+							pos:  position{line: 213, col: 86, offset: 5192},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 212, col: 89, offset: 5120},
+							pos:   position{line: 213, col: 89, offset: 5195},
 							label: "methods",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 212, col: 97, offset: 5128},
+								pos: position{line: 213, col: 97, offset: 5203},
 								expr: &seqExpr{
-									pos: position{line: 212, col: 98, offset: 5129},
+									pos: position{line: 213, col: 98, offset: 5204},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 212, col: 98, offset: 5129},
+											pos:  position{line: 213, col: 98, offset: 5204},
 											name: "Function",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 212, col: 107, offset: 5138},
+											pos:  position{line: 213, col: 107, offset: 5213},
 											name: "__",
 										},
 									},
@@ -946,36 +961,36 @@ var g = &grammar{
 							},
 						},
 						&choiceExpr{
-							pos: position{line: 212, col: 113, offset: 5144},
+							pos: position{line: 213, col: 113, offset: 5219},
 							alternatives: []interface{}{
 								&litMatcher{
-									pos:        position{line: 212, col: 113, offset: 5144},
+									pos:        position{line: 213, col: 113, offset: 5219},
 									val:        "}",
 									ignoreCase: false,
 								},
 								&ruleRefExpr{
-									pos:  position{line: 212, col: 119, offset: 5150},
+									pos:  position{line: 213, col: 119, offset: 5225},
 									name: "EndOfServiceError",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 212, col: 138, offset: 5169},
+							pos:  position{line: 213, col: 138, offset: 5244},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 212, col: 141, offset: 5172},
+							pos:   position{line: 213, col: 141, offset: 5247},
 							label: "annotations",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 212, col: 153, offset: 5184},
+								pos: position{line: 213, col: 153, offset: 5259},
 								expr: &ruleRefExpr{
-									pos:  position{line: 212, col: 153, offset: 5184},
+									pos:  position{line: 213, col: 153, offset: 5259},
 									name: "TypeAnnotations",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 212, col: 171, offset: 5202},
+							pos:  position{line: 213, col: 171, offset: 5277},
 							name: "EOS",
 						},
 					},
@@ -984,39 +999,39 @@ var g = &grammar{
 		},
 		{
 			name: "EndOfServiceError",
-			pos:  position{line: 228, col: 1, offset: 5586},
+			pos:  position{line: 229, col: 1, offset: 5661},
 			expr: &actionExpr{
-				pos: position{line: 228, col: 21, offset: 5608},
+				pos: position{line: 229, col: 21, offset: 5683},
 				run: (*parser).callonEndOfServiceError1,
 				expr: &anyMatcher{
-					line: 228, col: 21, offset: 5608,
+					line: 229, col: 21, offset: 5683,
 				},
 			},
 		},
 		{
 			name: "Function",
-			pos:  position{line: 232, col: 1, offset: 5674},
+			pos:  position{line: 233, col: 1, offset: 5749},
 			expr: &actionExpr{
-				pos: position{line: 232, col: 12, offset: 5687},
+				pos: position{line: 233, col: 12, offset: 5762},
 				run: (*parser).callonFunction1,
 				expr: &seqExpr{
-					pos: position{line: 232, col: 12, offset: 5687},
+					pos: position{line: 233, col: 12, offset: 5762},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 232, col: 12, offset: 5687},
+							pos:   position{line: 233, col: 12, offset: 5762},
 							label: "oneway",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 232, col: 19, offset: 5694},
+								pos: position{line: 233, col: 19, offset: 5769},
 								expr: &seqExpr{
-									pos: position{line: 232, col: 20, offset: 5695},
+									pos: position{line: 233, col: 20, offset: 5770},
 									exprs: []interface{}{
 										&litMatcher{
-											pos:        position{line: 232, col: 20, offset: 5695},
+											pos:        position{line: 233, col: 20, offset: 5770},
 											val:        "oneway",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 232, col: 29, offset: 5704},
+											pos:  position{line: 233, col: 29, offset: 5779},
 											name: "__",
 										},
 									},
@@ -1024,85 +1039,85 @@ var g = &grammar{
 							},
 						},
 						&labeledExpr{
-							pos:   position{line: 232, col: 34, offset: 5709},
+							pos:   position{line: 233, col: 34, offset: 5784},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 232, col: 38, offset: 5713},
+								pos:  position{line: 233, col: 38, offset: 5788},
 								name: "FunctionType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 232, col: 51, offset: 5726},
+							pos:  position{line: 233, col: 51, offset: 5801},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 232, col: 54, offset: 5729},
+							pos:   position{line: 233, col: 54, offset: 5804},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 232, col: 59, offset: 5734},
+								pos:  position{line: 233, col: 59, offset: 5809},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 232, col: 70, offset: 5745},
+							pos:  position{line: 233, col: 70, offset: 5820},
 							name: "_",
 						},
 						&litMatcher{
-							pos:        position{line: 232, col: 72, offset: 5747},
+							pos:        position{line: 233, col: 72, offset: 5822},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 232, col: 76, offset: 5751},
+							pos:  position{line: 233, col: 76, offset: 5826},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 232, col: 79, offset: 5754},
+							pos:   position{line: 233, col: 79, offset: 5829},
 							label: "arguments",
 							expr: &ruleRefExpr{
-								pos:  position{line: 232, col: 89, offset: 5764},
+								pos:  position{line: 233, col: 89, offset: 5839},
 								name: "FieldList",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 232, col: 99, offset: 5774},
+							pos:        position{line: 233, col: 99, offset: 5849},
 							val:        ")",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 232, col: 103, offset: 5778},
+							pos:  position{line: 233, col: 103, offset: 5853},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 232, col: 106, offset: 5781},
+							pos:   position{line: 233, col: 106, offset: 5856},
 							label: "exceptions",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 232, col: 117, offset: 5792},
+								pos: position{line: 233, col: 117, offset: 5867},
 								expr: &ruleRefExpr{
-									pos:  position{line: 232, col: 117, offset: 5792},
+									pos:  position{line: 233, col: 117, offset: 5867},
 									name: "Throws",
 								},
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 232, col: 125, offset: 5800},
+							pos:  position{line: 233, col: 125, offset: 5875},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 232, col: 128, offset: 5803},
+							pos:   position{line: 233, col: 128, offset: 5878},
 							label: "annotations",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 232, col: 140, offset: 5815},
+								pos: position{line: 233, col: 140, offset: 5890},
 								expr: &ruleRefExpr{
-									pos:  position{line: 232, col: 140, offset: 5815},
+									pos:  position{line: 233, col: 140, offset: 5890},
 									name: "TypeAnnotations",
 								},
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 232, col: 157, offset: 5832},
+							pos: position{line: 233, col: 157, offset: 5907},
 							expr: &ruleRefExpr{
-								pos:  position{line: 232, col: 157, offset: 5832},
+								pos:  position{line: 233, col: 157, offset: 5907},
 								name: "ListSeparator",
 							},
 						},
@@ -1112,23 +1127,23 @@ var g = &grammar{
 		},
 		{
 			name: "FunctionType",
-			pos:  position{line: 256, col: 1, offset: 6256},
+			pos:  position{line: 257, col: 1, offset: 6331},
 			expr: &actionExpr{
-				pos: position{line: 256, col: 16, offset: 6273},
+				pos: position{line: 257, col: 16, offset: 6348},
 				run: (*parser).callonFunctionType1,
 				expr: &labeledExpr{
-					pos:   position{line: 256, col: 16, offset: 6273},
+					pos:   position{line: 257, col: 16, offset: 6348},
 					label: "typ",
 					expr: &choiceExpr{
-						pos: position{line: 256, col: 21, offset: 6278},
+						pos: position{line: 257, col: 21, offset: 6353},
 						alternatives: []interface{}{
 							&litMatcher{
-								pos:        position{line: 256, col: 21, offset: 6278},
+								pos:        position{line: 257, col: 21, offset: 6353},
 								val:        "void",
 								ignoreCase: false,
 							},
 							&ruleRefExpr{
-								pos:  position{line: 256, col: 30, offset: 6287},
+								pos:  position{line: 257, col: 30, offset: 6362},
 								name: "FieldType",
 							},
 						},
@@ -1138,41 +1153,41 @@ var g = &grammar{
 		},
 		{
 			name: "Throws",
-			pos:  position{line: 263, col: 1, offset: 6394},
+			pos:  position{line: 264, col: 1, offset: 6469},
 			expr: &actionExpr{
-				pos: position{line: 263, col: 10, offset: 6405},
+				pos: position{line: 264, col: 10, offset: 6480},
 				run: (*parser).callonThrows1,
 				expr: &seqExpr{
-					pos: position{line: 263, col: 10, offset: 6405},
+					pos: position{line: 264, col: 10, offset: 6480},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 263, col: 10, offset: 6405},
+							pos:        position{line: 264, col: 10, offset: 6480},
 							val:        "throws",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 263, col: 19, offset: 6414},
+							pos:  position{line: 264, col: 19, offset: 6489},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 263, col: 22, offset: 6417},
+							pos:        position{line: 264, col: 22, offset: 6492},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 263, col: 26, offset: 6421},
+							pos:  position{line: 264, col: 26, offset: 6496},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 263, col: 29, offset: 6424},
+							pos:   position{line: 264, col: 29, offset: 6499},
 							label: "exceptions",
 							expr: &ruleRefExpr{
-								pos:  position{line: 263, col: 40, offset: 6435},
+								pos:  position{line: 264, col: 40, offset: 6510},
 								name: "FieldList",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 263, col: 50, offset: 6445},
+							pos:        position{line: 264, col: 50, offset: 6520},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -1182,26 +1197,26 @@ var g = &grammar{
 		},
 		{
 			name: "FieldType",
-			pos:  position{line: 267, col: 1, offset: 6478},
+			pos:  position{line: 268, col: 1, offset: 6553},
 			expr: &actionExpr{
-				pos: position{line: 267, col: 13, offset: 6492},
+				pos: position{line: 268, col: 13, offset: 6567},
 				run: (*parser).callonFieldType1,
 				expr: &labeledExpr{
-					pos:   position{line: 267, col: 13, offset: 6492},
+					pos:   position{line: 268, col: 13, offset: 6567},
 					label: "typ",
 					expr: &choiceExpr{
-						pos: position{line: 267, col: 18, offset: 6497},
+						pos: position{line: 268, col: 18, offset: 6572},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 267, col: 18, offset: 6497},
+								pos:  position{line: 268, col: 18, offset: 6572},
 								name: "BaseType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 267, col: 29, offset: 6508},
+								pos:  position{line: 268, col: 29, offset: 6583},
 								name: "ContainerType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 267, col: 45, offset: 6524},
+								pos:  position{line: 268, col: 45, offset: 6599},
 								name: "Identifier",
 							},
 						},
@@ -1211,22 +1226,22 @@ var g = &grammar{
 		},
 		{
 			name: "DefinitionType",
-			pos:  position{line: 274, col: 1, offset: 6634},
+			pos:  position{line: 275, col: 1, offset: 6709},
 			expr: &actionExpr{
-				pos: position{line: 274, col: 18, offset: 6653},
+				pos: position{line: 275, col: 18, offset: 6728},
 				run: (*parser).callonDefinitionType1,
 				expr: &labeledExpr{
-					pos:   position{line: 274, col: 18, offset: 6653},
+					pos:   position{line: 275, col: 18, offset: 6728},
 					label: "typ",
 					expr: &choiceExpr{
-						pos: position{line: 274, col: 23, offset: 6658},
+						pos: position{line: 275, col: 23, offset: 6733},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 274, col: 23, offset: 6658},
+								pos:  position{line: 275, col: 23, offset: 6733},
 								name: "BaseType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 274, col: 34, offset: 6669},
+								pos:  position{line: 275, col: 34, offset: 6744},
 								name: "ContainerType",
 							},
 						},
@@ -1236,32 +1251,32 @@ var g = &grammar{
 		},
 		{
 			name: "BaseType",
-			pos:  position{line: 278, col: 1, offset: 6706},
+			pos:  position{line: 279, col: 1, offset: 6781},
 			expr: &actionExpr{
-				pos: position{line: 278, col: 12, offset: 6719},
+				pos: position{line: 279, col: 12, offset: 6794},
 				run: (*parser).callonBaseType1,
 				expr: &seqExpr{
-					pos: position{line: 278, col: 12, offset: 6719},
+					pos: position{line: 279, col: 12, offset: 6794},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 278, col: 12, offset: 6719},
+							pos:   position{line: 279, col: 12, offset: 6794},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 278, col: 17, offset: 6724},
+								pos:  position{line: 279, col: 17, offset: 6799},
 								name: "BaseTypeName",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 278, col: 30, offset: 6737},
+							pos:  position{line: 279, col: 30, offset: 6812},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 278, col: 33, offset: 6740},
+							pos:   position{line: 279, col: 33, offset: 6815},
 							label: "annotations",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 278, col: 45, offset: 6752},
+								pos: position{line: 279, col: 45, offset: 6827},
 								expr: &ruleRefExpr{
-									pos:  position{line: 278, col: 45, offset: 6752},
+									pos:  position{line: 279, col: 45, offset: 6827},
 									name: "TypeAnnotations",
 								},
 							},
@@ -1272,50 +1287,50 @@ var g = &grammar{
 		},
 		{
 			name: "BaseTypeName",
-			pos:  position{line: 285, col: 1, offset: 6863},
+			pos:  position{line: 286, col: 1, offset: 6938},
 			expr: &actionExpr{
-				pos: position{line: 285, col: 16, offset: 6880},
+				pos: position{line: 286, col: 16, offset: 6955},
 				run: (*parser).callonBaseTypeName1,
 				expr: &choiceExpr{
-					pos: position{line: 285, col: 17, offset: 6881},
+					pos: position{line: 286, col: 17, offset: 6956},
 					alternatives: []interface{}{
 						&litMatcher{
-							pos:        position{line: 285, col: 17, offset: 6881},
+							pos:        position{line: 286, col: 17, offset: 6956},
 							val:        "bool",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 285, col: 26, offset: 6890},
+							pos:        position{line: 286, col: 26, offset: 6965},
 							val:        "byte",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 285, col: 35, offset: 6899},
+							pos:        position{line: 286, col: 35, offset: 6974},
 							val:        "i16",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 285, col: 43, offset: 6907},
+							pos:        position{line: 286, col: 43, offset: 6982},
 							val:        "i32",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 285, col: 51, offset: 6915},
+							pos:        position{line: 286, col: 51, offset: 6990},
 							val:        "i64",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 285, col: 59, offset: 6923},
+							pos:        position{line: 286, col: 59, offset: 6998},
 							val:        "double",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 285, col: 70, offset: 6934},
+							pos:        position{line: 286, col: 70, offset: 7009},
 							val:        "string",
 							ignoreCase: false,
 						},
 						&litMatcher{
-							pos:        position{line: 285, col: 81, offset: 6945},
+							pos:        position{line: 286, col: 81, offset: 7020},
 							val:        "binary",
 							ignoreCase: false,
 						},
@@ -1325,26 +1340,26 @@ var g = &grammar{
 		},
 		{
 			name: "ContainerType",
-			pos:  position{line: 289, col: 1, offset: 6989},
+			pos:  position{line: 290, col: 1, offset: 7064},
 			expr: &actionExpr{
-				pos: position{line: 289, col: 17, offset: 7007},
+				pos: position{line: 290, col: 17, offset: 7082},
 				run: (*parser).callonContainerType1,
 				expr: &labeledExpr{
-					pos:   position{line: 289, col: 17, offset: 7007},
+					pos:   position{line: 290, col: 17, offset: 7082},
 					label: "typ",
 					expr: &choiceExpr{
-						pos: position{line: 289, col: 22, offset: 7012},
+						pos: position{line: 290, col: 22, offset: 7087},
 						alternatives: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 289, col: 22, offset: 7012},
+								pos:  position{line: 290, col: 22, offset: 7087},
 								name: "MapType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 289, col: 32, offset: 7022},
+								pos:  position{line: 290, col: 32, offset: 7097},
 								name: "SetType",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 289, col: 42, offset: 7032},
+								pos:  position{line: 290, col: 42, offset: 7107},
 								name: "ListType",
 							},
 						},
@@ -1354,87 +1369,87 @@ var g = &grammar{
 		},
 		{
 			name: "MapType",
-			pos:  position{line: 293, col: 1, offset: 7064},
+			pos:  position{line: 294, col: 1, offset: 7139},
 			expr: &actionExpr{
-				pos: position{line: 293, col: 11, offset: 7076},
+				pos: position{line: 294, col: 11, offset: 7151},
 				run: (*parser).callonMapType1,
 				expr: &seqExpr{
-					pos: position{line: 293, col: 11, offset: 7076},
+					pos: position{line: 294, col: 11, offset: 7151},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 293, col: 11, offset: 7076},
+							pos: position{line: 294, col: 11, offset: 7151},
 							expr: &ruleRefExpr{
-								pos:  position{line: 293, col: 11, offset: 7076},
+								pos:  position{line: 294, col: 11, offset: 7151},
 								name: "CppType",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 293, col: 20, offset: 7085},
+							pos:        position{line: 294, col: 20, offset: 7160},
 							val:        "map",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 293, col: 26, offset: 7091},
+							pos:  position{line: 294, col: 26, offset: 7166},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 293, col: 29, offset: 7094},
+							pos:        position{line: 294, col: 29, offset: 7169},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 293, col: 33, offset: 7098},
+							pos:  position{line: 294, col: 33, offset: 7173},
 							name: "WS",
 						},
 						&labeledExpr{
-							pos:   position{line: 293, col: 36, offset: 7101},
+							pos:   position{line: 294, col: 36, offset: 7176},
 							label: "key",
 							expr: &ruleRefExpr{
-								pos:  position{line: 293, col: 40, offset: 7105},
+								pos:  position{line: 294, col: 40, offset: 7180},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 293, col: 50, offset: 7115},
+							pos:  position{line: 294, col: 50, offset: 7190},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 293, col: 53, offset: 7118},
+							pos:        position{line: 294, col: 53, offset: 7193},
 							val:        ",",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 293, col: 57, offset: 7122},
+							pos:  position{line: 294, col: 57, offset: 7197},
 							name: "WS",
 						},
 						&labeledExpr{
-							pos:   position{line: 293, col: 60, offset: 7125},
+							pos:   position{line: 294, col: 60, offset: 7200},
 							label: "value",
 							expr: &ruleRefExpr{
-								pos:  position{line: 293, col: 66, offset: 7131},
+								pos:  position{line: 294, col: 66, offset: 7206},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 293, col: 76, offset: 7141},
+							pos:  position{line: 294, col: 76, offset: 7216},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 293, col: 79, offset: 7144},
+							pos:        position{line: 294, col: 79, offset: 7219},
 							val:        ">",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 293, col: 83, offset: 7148},
+							pos:  position{line: 294, col: 83, offset: 7223},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 293, col: 86, offset: 7151},
+							pos:   position{line: 294, col: 86, offset: 7226},
 							label: "annotations",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 293, col: 98, offset: 7163},
+								pos: position{line: 294, col: 98, offset: 7238},
 								expr: &ruleRefExpr{
-									pos:  position{line: 293, col: 98, offset: 7163},
+									pos:  position{line: 294, col: 98, offset: 7238},
 									name: "TypeAnnotations",
 								},
 							},
@@ -1445,66 +1460,66 @@ var g = &grammar{
 		},
 		{
 			name: "SetType",
-			pos:  position{line: 302, col: 1, offset: 7318},
+			pos:  position{line: 303, col: 1, offset: 7393},
 			expr: &actionExpr{
-				pos: position{line: 302, col: 11, offset: 7330},
+				pos: position{line: 303, col: 11, offset: 7405},
 				run: (*parser).callonSetType1,
 				expr: &seqExpr{
-					pos: position{line: 302, col: 11, offset: 7330},
+					pos: position{line: 303, col: 11, offset: 7405},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 302, col: 11, offset: 7330},
+							pos: position{line: 303, col: 11, offset: 7405},
 							expr: &ruleRefExpr{
-								pos:  position{line: 302, col: 11, offset: 7330},
+								pos:  position{line: 303, col: 11, offset: 7405},
 								name: "CppType",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 302, col: 20, offset: 7339},
+							pos:        position{line: 303, col: 20, offset: 7414},
 							val:        "set",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 302, col: 26, offset: 7345},
+							pos:  position{line: 303, col: 26, offset: 7420},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 302, col: 29, offset: 7348},
+							pos:        position{line: 303, col: 29, offset: 7423},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 302, col: 33, offset: 7352},
+							pos:  position{line: 303, col: 33, offset: 7427},
 							name: "WS",
 						},
 						&labeledExpr{
-							pos:   position{line: 302, col: 36, offset: 7355},
+							pos:   position{line: 303, col: 36, offset: 7430},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 302, col: 40, offset: 7359},
+								pos:  position{line: 303, col: 40, offset: 7434},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 302, col: 50, offset: 7369},
+							pos:  position{line: 303, col: 50, offset: 7444},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 302, col: 53, offset: 7372},
+							pos:        position{line: 303, col: 53, offset: 7447},
 							val:        ">",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 302, col: 57, offset: 7376},
+							pos:  position{line: 303, col: 57, offset: 7451},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 302, col: 60, offset: 7379},
+							pos:   position{line: 303, col: 60, offset: 7454},
 							label: "annotations",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 302, col: 72, offset: 7391},
+								pos: position{line: 303, col: 72, offset: 7466},
 								expr: &ruleRefExpr{
-									pos:  position{line: 302, col: 72, offset: 7391},
+									pos:  position{line: 303, col: 72, offset: 7466},
 									name: "TypeAnnotations",
 								},
 							},
@@ -1515,59 +1530,59 @@ var g = &grammar{
 		},
 		{
 			name: "ListType",
-			pos:  position{line: 310, col: 1, offset: 7520},
+			pos:  position{line: 311, col: 1, offset: 7595},
 			expr: &actionExpr{
-				pos: position{line: 310, col: 12, offset: 7533},
+				pos: position{line: 311, col: 12, offset: 7608},
 				run: (*parser).callonListType1,
 				expr: &seqExpr{
-					pos: position{line: 310, col: 12, offset: 7533},
+					pos: position{line: 311, col: 12, offset: 7608},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 310, col: 12, offset: 7533},
+							pos:        position{line: 311, col: 12, offset: 7608},
 							val:        "list",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 310, col: 19, offset: 7540},
+							pos:  position{line: 311, col: 19, offset: 7615},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 310, col: 22, offset: 7543},
+							pos:        position{line: 311, col: 22, offset: 7618},
 							val:        "<",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 310, col: 26, offset: 7547},
+							pos:  position{line: 311, col: 26, offset: 7622},
 							name: "WS",
 						},
 						&labeledExpr{
-							pos:   position{line: 310, col: 29, offset: 7550},
+							pos:   position{line: 311, col: 29, offset: 7625},
 							label: "typ",
 							expr: &ruleRefExpr{
-								pos:  position{line: 310, col: 33, offset: 7554},
+								pos:  position{line: 311, col: 33, offset: 7629},
 								name: "FieldType",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 310, col: 43, offset: 7564},
+							pos:  position{line: 311, col: 43, offset: 7639},
 							name: "WS",
 						},
 						&litMatcher{
-							pos:        position{line: 310, col: 46, offset: 7567},
+							pos:        position{line: 311, col: 46, offset: 7642},
 							val:        ">",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 310, col: 50, offset: 7571},
+							pos:  position{line: 311, col: 50, offset: 7646},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 310, col: 53, offset: 7574},
+							pos:   position{line: 311, col: 53, offset: 7649},
 							label: "annotations",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 310, col: 65, offset: 7586},
+								pos: position{line: 311, col: 65, offset: 7661},
 								expr: &ruleRefExpr{
-									pos:  position{line: 310, col: 65, offset: 7586},
+									pos:  position{line: 311, col: 65, offset: 7661},
 									name: "TypeAnnotations",
 								},
 							},
@@ -1578,23 +1593,23 @@ var g = &grammar{
 		},
 		{
 			name: "CppType",
-			pos:  position{line: 318, col: 1, offset: 7716},
+			pos:  position{line: 319, col: 1, offset: 7791},
 			expr: &actionExpr{
-				pos: position{line: 318, col: 11, offset: 7728},
+				pos: position{line: 319, col: 11, offset: 7803},
 				run: (*parser).callonCppType1,
 				expr: &seqExpr{
-					pos: position{line: 318, col: 11, offset: 7728},
+					pos: position{line: 319, col: 11, offset: 7803},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 318, col: 11, offset: 7728},
+							pos:        position{line: 319, col: 11, offset: 7803},
 							val:        "cpp_type",
 							ignoreCase: false,
 						},
 						&labeledExpr{
-							pos:   position{line: 318, col: 22, offset: 7739},
+							pos:   position{line: 319, col: 22, offset: 7814},
 							label: "cppType",
 							expr: &ruleRefExpr{
-								pos:  position{line: 318, col: 30, offset: 7747},
+								pos:  position{line: 319, col: 30, offset: 7822},
 								name: "Literal",
 							},
 						},
@@ -1604,32 +1619,32 @@ var g = &grammar{
 		},
 		{
 			name: "ConstValue",
-			pos:  position{line: 322, col: 1, offset: 7781},
+			pos:  position{line: 323, col: 1, offset: 7856},
 			expr: &choiceExpr{
-				pos: position{line: 322, col: 14, offset: 7796},
+				pos: position{line: 323, col: 14, offset: 7871},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 322, col: 14, offset: 7796},
+						pos:  position{line: 323, col: 14, offset: 7871},
 						name: "Literal",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 322, col: 24, offset: 7806},
+						pos:  position{line: 323, col: 24, offset: 7881},
 						name: "DoubleConstant",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 322, col: 41, offset: 7823},
+						pos:  position{line: 323, col: 41, offset: 7898},
 						name: "IntConstant",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 322, col: 55, offset: 7837},
+						pos:  position{line: 323, col: 55, offset: 7912},
 						name: "ConstMap",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 322, col: 66, offset: 7848},
+						pos:  position{line: 323, col: 66, offset: 7923},
 						name: "ConstList",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 322, col: 78, offset: 7860},
+						pos:  position{line: 323, col: 78, offset: 7935},
 						name: "Identifier",
 					},
 				},
@@ -1637,35 +1652,35 @@ var g = &grammar{
 		},
 		{
 			name: "TypeAnnotations",
-			pos:  position{line: 324, col: 1, offset: 7872},
+			pos:  position{line: 325, col: 1, offset: 7947},
 			expr: &actionExpr{
-				pos: position{line: 324, col: 19, offset: 7892},
+				pos: position{line: 325, col: 19, offset: 7967},
 				run: (*parser).callonTypeAnnotations1,
 				expr: &seqExpr{
-					pos: position{line: 324, col: 19, offset: 7892},
+					pos: position{line: 325, col: 19, offset: 7967},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 324, col: 19, offset: 7892},
+							pos:        position{line: 325, col: 19, offset: 7967},
 							val:        "(",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 324, col: 23, offset: 7896},
+							pos:  position{line: 325, col: 23, offset: 7971},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 324, col: 26, offset: 7899},
+							pos:   position{line: 325, col: 26, offset: 7974},
 							label: "annotations",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 324, col: 38, offset: 7911},
+								pos: position{line: 325, col: 38, offset: 7986},
 								expr: &ruleRefExpr{
-									pos:  position{line: 324, col: 38, offset: 7911},
+									pos:  position{line: 325, col: 38, offset: 7986},
 									name: "TypeAnnotation",
 								},
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 324, col: 54, offset: 7927},
+							pos:        position{line: 325, col: 54, offset: 8002},
 							val:        ")",
 							ignoreCase: false,
 						},
@@ -1675,50 +1690,50 @@ var g = &grammar{
 		},
 		{
 			name: "TypeAnnotation",
-			pos:  position{line: 332, col: 1, offset: 8073},
+			pos:  position{line: 333, col: 1, offset: 8148},
 			expr: &actionExpr{
-				pos: position{line: 332, col: 18, offset: 8092},
+				pos: position{line: 333, col: 18, offset: 8167},
 				run: (*parser).callonTypeAnnotation1,
 				expr: &seqExpr{
-					pos: position{line: 332, col: 18, offset: 8092},
+					pos: position{line: 333, col: 18, offset: 8167},
 					exprs: []interface{}{
 						&labeledExpr{
-							pos:   position{line: 332, col: 18, offset: 8092},
+							pos:   position{line: 333, col: 18, offset: 8167},
 							label: "name",
 							expr: &ruleRefExpr{
-								pos:  position{line: 332, col: 23, offset: 8097},
+								pos:  position{line: 333, col: 23, offset: 8172},
 								name: "Identifier",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 332, col: 34, offset: 8108},
+							pos:  position{line: 333, col: 34, offset: 8183},
 							name: "_",
 						},
 						&labeledExpr{
-							pos:   position{line: 332, col: 36, offset: 8110},
+							pos:   position{line: 333, col: 36, offset: 8185},
 							label: "value",
 							expr: &zeroOrOneExpr{
-								pos: position{line: 332, col: 42, offset: 8116},
+								pos: position{line: 333, col: 42, offset: 8191},
 								expr: &actionExpr{
-									pos: position{line: 332, col: 43, offset: 8117},
+									pos: position{line: 333, col: 43, offset: 8192},
 									run: (*parser).callonTypeAnnotation8,
 									expr: &seqExpr{
-										pos: position{line: 332, col: 43, offset: 8117},
+										pos: position{line: 333, col: 43, offset: 8192},
 										exprs: []interface{}{
 											&litMatcher{
-												pos:        position{line: 332, col: 43, offset: 8117},
+												pos:        position{line: 333, col: 43, offset: 8192},
 												val:        "=",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 332, col: 47, offset: 8121},
+												pos:  position{line: 333, col: 47, offset: 8196},
 												name: "__",
 											},
 											&labeledExpr{
-												pos:   position{line: 332, col: 50, offset: 8124},
+												pos:   position{line: 333, col: 50, offset: 8199},
 												label: "value",
 												expr: &ruleRefExpr{
-													pos:  position{line: 332, col: 56, offset: 8130},
+													pos:  position{line: 333, col: 56, offset: 8205},
 													name: "Literal",
 												},
 											},
@@ -1728,14 +1743,14 @@ var g = &grammar{
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 332, col: 88, offset: 8162},
+							pos: position{line: 333, col: 88, offset: 8237},
 							expr: &ruleRefExpr{
-								pos:  position{line: 332, col: 88, offset: 8162},
+								pos:  position{line: 333, col: 88, offset: 8237},
 								name: "ListSeparator",
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 332, col: 103, offset: 8177},
+							pos:  position{line: 333, col: 103, offset: 8252},
 							name: "__",
 						},
 					},
@@ -1744,17 +1759,17 @@ var g = &grammar{
 		},
 		{
 			name: "IntConstant",
-			pos:  position{line: 343, col: 1, offset: 8340},
+			pos:  position{line: 344, col: 1, offset: 8415},
 			expr: &actionExpr{
-				pos: position{line: 343, col: 15, offset: 8356},
+				pos: position{line: 344, col: 15, offset: 8431},
 				run: (*parser).callonIntConstant1,
 				expr: &seqExpr{
-					pos: position{line: 343, col: 15, offset: 8356},
+					pos: position{line: 344, col: 15, offset: 8431},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 343, col: 15, offset: 8356},
+							pos: position{line: 344, col: 15, offset: 8431},
 							expr: &charClassMatcher{
-								pos:        position{line: 343, col: 15, offset: 8356},
+								pos:        position{line: 344, col: 15, offset: 8431},
 								val:        "[-+]",
 								chars:      []rune{'-', '+'},
 								ignoreCase: false,
@@ -1762,9 +1777,9 @@ var g = &grammar{
 							},
 						},
 						&oneOrMoreExpr{
-							pos: position{line: 343, col: 21, offset: 8362},
+							pos: position{line: 344, col: 21, offset: 8437},
 							expr: &ruleRefExpr{
-								pos:  position{line: 343, col: 21, offset: 8362},
+								pos:  position{line: 344, col: 21, offset: 8437},
 								name: "Digit",
 							},
 						},
@@ -1774,17 +1789,17 @@ var g = &grammar{
 		},
 		{
 			name: "DoubleConstant",
-			pos:  position{line: 347, col: 1, offset: 8423},
+			pos:  position{line: 348, col: 1, offset: 8498},
 			expr: &actionExpr{
-				pos: position{line: 347, col: 18, offset: 8442},
+				pos: position{line: 348, col: 18, offset: 8517},
 				run: (*parser).callonDoubleConstant1,
 				expr: &seqExpr{
-					pos: position{line: 347, col: 18, offset: 8442},
+					pos: position{line: 348, col: 18, offset: 8517},
 					exprs: []interface{}{
 						&zeroOrOneExpr{
-							pos: position{line: 347, col: 18, offset: 8442},
+							pos: position{line: 348, col: 18, offset: 8517},
 							expr: &charClassMatcher{
-								pos:        position{line: 347, col: 18, offset: 8442},
+								pos:        position{line: 348, col: 18, offset: 8517},
 								val:        "[+-]",
 								chars:      []rune{'+', '-'},
 								ignoreCase: false,
@@ -1792,38 +1807,38 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 347, col: 24, offset: 8448},
+							pos: position{line: 348, col: 24, offset: 8523},
 							expr: &ruleRefExpr{
-								pos:  position{line: 347, col: 24, offset: 8448},
+								pos:  position{line: 348, col: 24, offset: 8523},
 								name: "Digit",
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 347, col: 31, offset: 8455},
+							pos:        position{line: 348, col: 31, offset: 8530},
 							val:        ".",
 							ignoreCase: false,
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 347, col: 35, offset: 8459},
+							pos: position{line: 348, col: 35, offset: 8534},
 							expr: &ruleRefExpr{
-								pos:  position{line: 347, col: 35, offset: 8459},
+								pos:  position{line: 348, col: 35, offset: 8534},
 								name: "Digit",
 							},
 						},
 						&zeroOrOneExpr{
-							pos: position{line: 347, col: 42, offset: 8466},
+							pos: position{line: 348, col: 42, offset: 8541},
 							expr: &seqExpr{
-								pos: position{line: 347, col: 44, offset: 8468},
+								pos: position{line: 348, col: 44, offset: 8543},
 								exprs: []interface{}{
 									&charClassMatcher{
-										pos:        position{line: 347, col: 44, offset: 8468},
+										pos:        position{line: 348, col: 44, offset: 8543},
 										val:        "['Ee']",
 										chars:      []rune{'\'', 'E', 'e', '\''},
 										ignoreCase: false,
 										inverted:   false,
 									},
 									&ruleRefExpr{
-										pos:  position{line: 347, col: 51, offset: 8475},
+										pos:  position{line: 348, col: 51, offset: 8550},
 										name: "IntConstant",
 									},
 								},
@@ -1835,47 +1850,47 @@ var g = &grammar{
 		},
 		{
 			name: "ConstList",
-			pos:  position{line: 351, col: 1, offset: 8542},
+			pos:  position{line: 352, col: 1, offset: 8617},
 			expr: &actionExpr{
-				pos: position{line: 351, col: 13, offset: 8556},
+				pos: position{line: 352, col: 13, offset: 8631},
 				run: (*parser).callonConstList1,
 				expr: &seqExpr{
-					pos: position{line: 351, col: 13, offset: 8556},
+					pos: position{line: 352, col: 13, offset: 8631},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 351, col: 13, offset: 8556},
+							pos:        position{line: 352, col: 13, offset: 8631},
 							val:        "[",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 351, col: 17, offset: 8560},
+							pos:  position{line: 352, col: 17, offset: 8635},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 351, col: 20, offset: 8563},
+							pos:   position{line: 352, col: 20, offset: 8638},
 							label: "values",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 351, col: 27, offset: 8570},
+								pos: position{line: 352, col: 27, offset: 8645},
 								expr: &seqExpr{
-									pos: position{line: 351, col: 28, offset: 8571},
+									pos: position{line: 352, col: 28, offset: 8646},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 351, col: 28, offset: 8571},
+											pos:  position{line: 352, col: 28, offset: 8646},
 											name: "ConstValue",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 351, col: 39, offset: 8582},
+											pos:  position{line: 352, col: 39, offset: 8657},
 											name: "__",
 										},
 										&zeroOrOneExpr{
-											pos: position{line: 351, col: 42, offset: 8585},
+											pos: position{line: 352, col: 42, offset: 8660},
 											expr: &ruleRefExpr{
-												pos:  position{line: 351, col: 42, offset: 8585},
+												pos:  position{line: 352, col: 42, offset: 8660},
 												name: "ListSeparator",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 351, col: 57, offset: 8600},
+											pos:  position{line: 352, col: 57, offset: 8675},
 											name: "__",
 										},
 									},
@@ -1883,11 +1898,11 @@ var g = &grammar{
 							},
 						},
 						&ruleRefExpr{
-							pos:  position{line: 351, col: 62, offset: 8605},
+							pos:  position{line: 352, col: 62, offset: 8680},
 							name: "__",
 						},
 						&litMatcher{
-							pos:        position{line: 351, col: 65, offset: 8608},
+							pos:        position{line: 352, col: 65, offset: 8683},
 							val:        "]",
 							ignoreCase: false,
 						},
@@ -1897,67 +1912,67 @@ var g = &grammar{
 		},
 		{
 			name: "ConstMap",
-			pos:  position{line: 360, col: 1, offset: 8781},
+			pos:  position{line: 361, col: 1, offset: 8856},
 			expr: &actionExpr{
-				pos: position{line: 360, col: 12, offset: 8794},
+				pos: position{line: 361, col: 12, offset: 8869},
 				run: (*parser).callonConstMap1,
 				expr: &seqExpr{
-					pos: position{line: 360, col: 12, offset: 8794},
+					pos: position{line: 361, col: 12, offset: 8869},
 					exprs: []interface{}{
 						&litMatcher{
-							pos:        position{line: 360, col: 12, offset: 8794},
+							pos:        position{line: 361, col: 12, offset: 8869},
 							val:        "{",
 							ignoreCase: false,
 						},
 						&ruleRefExpr{
-							pos:  position{line: 360, col: 16, offset: 8798},
+							pos:  position{line: 361, col: 16, offset: 8873},
 							name: "__",
 						},
 						&labeledExpr{
-							pos:   position{line: 360, col: 19, offset: 8801},
+							pos:   position{line: 361, col: 19, offset: 8876},
 							label: "values",
 							expr: &zeroOrMoreExpr{
-								pos: position{line: 360, col: 26, offset: 8808},
+								pos: position{line: 361, col: 26, offset: 8883},
 								expr: &seqExpr{
-									pos: position{line: 360, col: 27, offset: 8809},
+									pos: position{line: 361, col: 27, offset: 8884},
 									exprs: []interface{}{
 										&ruleRefExpr{
-											pos:  position{line: 360, col: 27, offset: 8809},
+											pos:  position{line: 361, col: 27, offset: 8884},
 											name: "ConstValue",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 360, col: 38, offset: 8820},
+											pos:  position{line: 361, col: 38, offset: 8895},
 											name: "__",
 										},
 										&litMatcher{
-											pos:        position{line: 360, col: 41, offset: 8823},
+											pos:        position{line: 361, col: 41, offset: 8898},
 											val:        ":",
 											ignoreCase: false,
 										},
 										&ruleRefExpr{
-											pos:  position{line: 360, col: 45, offset: 8827},
+											pos:  position{line: 361, col: 45, offset: 8902},
 											name: "__",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 360, col: 48, offset: 8830},
+											pos:  position{line: 361, col: 48, offset: 8905},
 											name: "ConstValue",
 										},
 										&ruleRefExpr{
-											pos:  position{line: 360, col: 59, offset: 8841},
+											pos:  position{line: 361, col: 59, offset: 8916},
 											name: "__",
 										},
 										&choiceExpr{
-											pos: position{line: 360, col: 63, offset: 8845},
+											pos: position{line: 361, col: 63, offset: 8920},
 											alternatives: []interface{}{
 												&litMatcher{
-													pos:        position{line: 360, col: 63, offset: 8845},
+													pos:        position{line: 361, col: 63, offset: 8920},
 													val:        ",",
 													ignoreCase: false,
 												},
 												&andExpr{
-													pos: position{line: 360, col: 69, offset: 8851},
+													pos: position{line: 361, col: 69, offset: 8926},
 													expr: &litMatcher{
-														pos:        position{line: 360, col: 70, offset: 8852},
+														pos:        position{line: 361, col: 70, offset: 8927},
 														val:        "}",
 														ignoreCase: false,
 													},
@@ -1965,7 +1980,7 @@ var g = &grammar{
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 360, col: 75, offset: 8857},
+											pos:  position{line: 361, col: 75, offset: 8932},
 											name: "__",
 										},
 									},
@@ -1973,7 +1988,7 @@ var g = &grammar{
 							},
 						},
 						&litMatcher{
-							pos:        position{line: 360, col: 80, offset: 8862},
+							pos:        position{line: 361, col: 80, offset: 8937},
 							val:        "}",
 							ignoreCase: false,
 						},
@@ -1983,33 +1998,33 @@ var g = &grammar{
 		},
 		{
 			name: "Literal",
-			pos:  position{line: 376, col: 1, offset: 9108},
+			pos:  position{line: 377, col: 1, offset: 9183},
 			expr: &actionExpr{
-				pos: position{line: 376, col: 11, offset: 9120},
+				pos: position{line: 377, col: 11, offset: 9195},
 				run: (*parser).callonLiteral1,
 				expr: &choiceExpr{
-					pos: position{line: 376, col: 12, offset: 9121},
+					pos: position{line: 377, col: 12, offset: 9196},
 					alternatives: []interface{}{
 						&seqExpr{
-							pos: position{line: 376, col: 13, offset: 9122},
+							pos: position{line: 377, col: 13, offset: 9197},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 376, col: 13, offset: 9122},
+									pos:        position{line: 377, col: 13, offset: 9197},
 									val:        "\"",
 									ignoreCase: false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 376, col: 17, offset: 9126},
+									pos: position{line: 377, col: 17, offset: 9201},
 									expr: &choiceExpr{
-										pos: position{line: 376, col: 18, offset: 9127},
+										pos: position{line: 377, col: 18, offset: 9202},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 376, col: 18, offset: 9127},
+												pos:        position{line: 377, col: 18, offset: 9202},
 												val:        "\\\"",
 												ignoreCase: false,
 											},
 											&charClassMatcher{
-												pos:        position{line: 376, col: 25, offset: 9134},
+												pos:        position{line: 377, col: 25, offset: 9209},
 												val:        "[^\"]",
 												chars:      []rune{'"'},
 												ignoreCase: false,
@@ -2019,32 +2034,32 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 376, col: 32, offset: 9141},
+									pos:        position{line: 377, col: 32, offset: 9216},
 									val:        "\"",
 									ignoreCase: false,
 								},
 							},
 						},
 						&seqExpr{
-							pos: position{line: 376, col: 40, offset: 9149},
+							pos: position{line: 377, col: 40, offset: 9224},
 							exprs: []interface{}{
 								&litMatcher{
-									pos:        position{line: 376, col: 40, offset: 9149},
+									pos:        position{line: 377, col: 40, offset: 9224},
 									val:        "'",
 									ignoreCase: false,
 								},
 								&zeroOrMoreExpr{
-									pos: position{line: 376, col: 45, offset: 9154},
+									pos: position{line: 377, col: 45, offset: 9229},
 									expr: &choiceExpr{
-										pos: position{line: 376, col: 46, offset: 9155},
+										pos: position{line: 377, col: 46, offset: 9230},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 376, col: 46, offset: 9155},
+												pos:        position{line: 377, col: 46, offset: 9230},
 												val:        "\\'",
 												ignoreCase: false,
 											},
 											&charClassMatcher{
-												pos:        position{line: 376, col: 53, offset: 9162},
+												pos:        position{line: 377, col: 53, offset: 9237},
 												val:        "[^']",
 												chars:      []rune{'\''},
 												ignoreCase: false,
@@ -2054,7 +2069,7 @@ var g = &grammar{
 									},
 								},
 								&litMatcher{
-									pos:        position{line: 376, col: 60, offset: 9169},
+									pos:        position{line: 377, col: 60, offset: 9244},
 									val:        "'",
 									ignoreCase: false,
 								},
@@ -2066,24 +2081,24 @@ var g = &grammar{
 		},
 		{
 			name: "Identifier",
-			pos:  position{line: 383, col: 1, offset: 9370},
+			pos:  position{line: 384, col: 1, offset: 9445},
 			expr: &actionExpr{
-				pos: position{line: 383, col: 14, offset: 9385},
+				pos: position{line: 384, col: 14, offset: 9460},
 				run: (*parser).callonIdentifier1,
 				expr: &seqExpr{
-					pos: position{line: 383, col: 14, offset: 9385},
+					pos: position{line: 384, col: 14, offset: 9460},
 					exprs: []interface{}{
 						&oneOrMoreExpr{
-							pos: position{line: 383, col: 14, offset: 9385},
+							pos: position{line: 384, col: 14, offset: 9460},
 							expr: &choiceExpr{
-								pos: position{line: 383, col: 15, offset: 9386},
+								pos: position{line: 384, col: 15, offset: 9461},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 383, col: 15, offset: 9386},
+										pos:  position{line: 384, col: 15, offset: 9461},
 										name: "Letter",
 									},
 									&litMatcher{
-										pos:        position{line: 383, col: 24, offset: 9395},
+										pos:        position{line: 384, col: 24, offset: 9470},
 										val:        "_",
 										ignoreCase: false,
 									},
@@ -2091,20 +2106,20 @@ var g = &grammar{
 							},
 						},
 						&zeroOrMoreExpr{
-							pos: position{line: 383, col: 30, offset: 9401},
+							pos: position{line: 384, col: 30, offset: 9476},
 							expr: &choiceExpr{
-								pos: position{line: 383, col: 31, offset: 9402},
+								pos: position{line: 384, col: 31, offset: 9477},
 								alternatives: []interface{}{
 									&ruleRefExpr{
-										pos:  position{line: 383, col: 31, offset: 9402},
+										pos:  position{line: 384, col: 31, offset: 9477},
 										name: "Letter",
 									},
 									&ruleRefExpr{
-										pos:  position{line: 383, col: 40, offset: 9411},
+										pos:  position{line: 384, col: 40, offset: 9486},
 										name: "Digit",
 									},
 									&charClassMatcher{
-										pos:        position{line: 383, col: 48, offset: 9419},
+										pos:        position{line: 384, col: 48, offset: 9494},
 										val:        "[._]",
 										chars:      []rune{'.', '_'},
 										ignoreCase: false,
@@ -2119,9 +2134,9 @@ var g = &grammar{
 		},
 		{
 			name: "ListSeparator",
-			pos:  position{line: 387, col: 1, offset: 9471},
+			pos:  position{line: 388, col: 1, offset: 9546},
 			expr: &charClassMatcher{
-				pos:        position{line: 387, col: 17, offset: 9489},
+				pos:        position{line: 388, col: 17, offset: 9564},
 				val:        "[,;]",
 				chars:      []rune{',', ';'},
 				ignoreCase: false,
@@ -2130,9 +2145,9 @@ var g = &grammar{
 		},
 		{
 			name: "Letter",
-			pos:  position{line: 388, col: 1, offset: 9494},
+			pos:  position{line: 389, col: 1, offset: 9569},
 			expr: &charClassMatcher{
-				pos:        position{line: 388, col: 10, offset: 9505},
+				pos:        position{line: 389, col: 10, offset: 9580},
 				val:        "[A-Za-z]",
 				ranges:     []rune{'A', 'Z', 'a', 'z'},
 				ignoreCase: false,
@@ -2141,9 +2156,9 @@ var g = &grammar{
 		},
 		{
 			name: "Digit",
-			pos:  position{line: 389, col: 1, offset: 9514},
+			pos:  position{line: 390, col: 1, offset: 9589},
 			expr: &charClassMatcher{
-				pos:        position{line: 389, col: 9, offset: 9524},
+				pos:        position{line: 390, col: 9, offset: 9599},
 				val:        "[0-9]",
 				ranges:     []rune{'0', '9'},
 				ignoreCase: false,
@@ -2152,23 +2167,23 @@ var g = &grammar{
 		},
 		{
 			name: "SourceChar",
-			pos:  position{line: 393, col: 1, offset: 9535},
+			pos:  position{line: 394, col: 1, offset: 9610},
 			expr: &anyMatcher{
-				line: 393, col: 14, offset: 9550,
+				line: 394, col: 14, offset: 9625,
 			},
 		},
 		{
 			name: "Comment",
-			pos:  position{line: 394, col: 1, offset: 9552},
+			pos:  position{line: 395, col: 1, offset: 9627},
 			expr: &choiceExpr{
-				pos: position{line: 394, col: 11, offset: 9564},
+				pos: position{line: 395, col: 11, offset: 9639},
 				alternatives: []interface{}{
 					&ruleRefExpr{
-						pos:  position{line: 394, col: 11, offset: 9564},
+						pos:  position{line: 395, col: 11, offset: 9639},
 						name: "MultiLineComment",
 					},
 					&ruleRefExpr{
-						pos:  position{line: 394, col: 30, offset: 9583},
+						pos:  position{line: 395, col: 30, offset: 9658},
 						name: "SingleLineComment",
 					},
 				},
@@ -2176,37 +2191,37 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineComment",
-			pos:  position{line: 395, col: 1, offset: 9601},
+			pos:  position{line: 396, col: 1, offset: 9676},
 			expr: &seqExpr{
-				pos: position{line: 395, col: 20, offset: 9622},
+				pos: position{line: 396, col: 20, offset: 9697},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 395, col: 20, offset: 9622},
+						pos:        position{line: 396, col: 20, offset: 9697},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 395, col: 25, offset: 9627},
+						pos: position{line: 396, col: 25, offset: 9702},
 						expr: &seqExpr{
-							pos: position{line: 395, col: 27, offset: 9629},
+							pos: position{line: 396, col: 27, offset: 9704},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 395, col: 27, offset: 9629},
+									pos: position{line: 396, col: 27, offset: 9704},
 									expr: &litMatcher{
-										pos:        position{line: 395, col: 28, offset: 9630},
+										pos:        position{line: 396, col: 28, offset: 9705},
 										val:        "*/",
 										ignoreCase: false,
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 395, col: 33, offset: 9635},
+									pos:  position{line: 396, col: 33, offset: 9710},
 									name: "SourceChar",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 395, col: 47, offset: 9649},
+						pos:        position{line: 396, col: 47, offset: 9724},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -2215,46 +2230,46 @@ var g = &grammar{
 		},
 		{
 			name: "MultiLineCommentNoLineTerminator",
-			pos:  position{line: 396, col: 1, offset: 9654},
+			pos:  position{line: 397, col: 1, offset: 9729},
 			expr: &seqExpr{
-				pos: position{line: 396, col: 36, offset: 9691},
+				pos: position{line: 397, col: 36, offset: 9766},
 				exprs: []interface{}{
 					&litMatcher{
-						pos:        position{line: 396, col: 36, offset: 9691},
+						pos:        position{line: 397, col: 36, offset: 9766},
 						val:        "/*",
 						ignoreCase: false,
 					},
 					&zeroOrMoreExpr{
-						pos: position{line: 396, col: 41, offset: 9696},
+						pos: position{line: 397, col: 41, offset: 9771},
 						expr: &seqExpr{
-							pos: position{line: 396, col: 43, offset: 9698},
+							pos: position{line: 397, col: 43, offset: 9773},
 							exprs: []interface{}{
 								&notExpr{
-									pos: position{line: 396, col: 43, offset: 9698},
+									pos: position{line: 397, col: 43, offset: 9773},
 									expr: &choiceExpr{
-										pos: position{line: 396, col: 46, offset: 9701},
+										pos: position{line: 397, col: 46, offset: 9776},
 										alternatives: []interface{}{
 											&litMatcher{
-												pos:        position{line: 396, col: 46, offset: 9701},
+												pos:        position{line: 397, col: 46, offset: 9776},
 												val:        "*/",
 												ignoreCase: false,
 											},
 											&ruleRefExpr{
-												pos:  position{line: 396, col: 53, offset: 9708},
+												pos:  position{line: 397, col: 53, offset: 9783},
 												name: "EOL",
 											},
 										},
 									},
 								},
 								&ruleRefExpr{
-									pos:  position{line: 396, col: 59, offset: 9714},
+									pos:  position{line: 397, col: 59, offset: 9789},
 									name: "SourceChar",
 								},
 							},
 						},
 					},
 					&litMatcher{
-						pos:        position{line: 396, col: 73, offset: 9728},
+						pos:        position{line: 397, col: 73, offset: 9803},
 						val:        "*/",
 						ignoreCase: false,
 					},
@@ -2263,32 +2278,32 @@ var g = &grammar{
 		},
 		{
 			name: "SingleLineComment",
-			pos:  position{line: 397, col: 1, offset: 9733},
+			pos:  position{line: 398, col: 1, offset: 9808},
 			expr: &choiceExpr{
-				pos: position{line: 397, col: 21, offset: 9755},
+				pos: position{line: 398, col: 21, offset: 9830},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 397, col: 22, offset: 9756},
+						pos: position{line: 398, col: 22, offset: 9831},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 397, col: 22, offset: 9756},
+								pos:        position{line: 398, col: 22, offset: 9831},
 								val:        "//",
 								ignoreCase: false,
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 397, col: 27, offset: 9761},
+								pos: position{line: 398, col: 27, offset: 9836},
 								expr: &seqExpr{
-									pos: position{line: 397, col: 29, offset: 9763},
+									pos: position{line: 398, col: 29, offset: 9838},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 397, col: 29, offset: 9763},
+											pos: position{line: 398, col: 29, offset: 9838},
 											expr: &ruleRefExpr{
-												pos:  position{line: 397, col: 30, offset: 9764},
+												pos:  position{line: 398, col: 30, offset: 9839},
 												name: "EOL",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 397, col: 34, offset: 9768},
+											pos:  position{line: 398, col: 34, offset: 9843},
 											name: "SourceChar",
 										},
 									},
@@ -2297,27 +2312,27 @@ var g = &grammar{
 						},
 					},
 					&seqExpr{
-						pos: position{line: 397, col: 52, offset: 9786},
+						pos: position{line: 398, col: 52, offset: 9861},
 						exprs: []interface{}{
 							&litMatcher{
-								pos:        position{line: 397, col: 52, offset: 9786},
+								pos:        position{line: 398, col: 52, offset: 9861},
 								val:        "#",
 								ignoreCase: false,
 							},
 							&zeroOrMoreExpr{
-								pos: position{line: 397, col: 56, offset: 9790},
+								pos: position{line: 398, col: 56, offset: 9865},
 								expr: &seqExpr{
-									pos: position{line: 397, col: 58, offset: 9792},
+									pos: position{line: 398, col: 58, offset: 9867},
 									exprs: []interface{}{
 										&notExpr{
-											pos: position{line: 397, col: 58, offset: 9792},
+											pos: position{line: 398, col: 58, offset: 9867},
 											expr: &ruleRefExpr{
-												pos:  position{line: 397, col: 59, offset: 9793},
+												pos:  position{line: 398, col: 59, offset: 9868},
 												name: "EOL",
 											},
 										},
 										&ruleRefExpr{
-											pos:  position{line: 397, col: 63, offset: 9797},
+											pos:  position{line: 398, col: 63, offset: 9872},
 											name: "SourceChar",
 										},
 									},
@@ -2330,22 +2345,22 @@ var g = &grammar{
 		},
 		{
 			name: "__",
-			pos:  position{line: 399, col: 1, offset: 9813},
+			pos:  position{line: 400, col: 1, offset: 9888},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 399, col: 6, offset: 9820},
+				pos: position{line: 400, col: 6, offset: 9895},
 				expr: &choiceExpr{
-					pos: position{line: 399, col: 8, offset: 9822},
+					pos: position{line: 400, col: 8, offset: 9897},
 					alternatives: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 399, col: 8, offset: 9822},
+							pos:  position{line: 400, col: 8, offset: 9897},
 							name: "Whitespace",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 399, col: 21, offset: 9835},
+							pos:  position{line: 400, col: 21, offset: 9910},
 							name: "EOL",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 399, col: 27, offset: 9841},
+							pos:  position{line: 400, col: 27, offset: 9916},
 							name: "Comment",
 						},
 					},
@@ -2354,18 +2369,18 @@ var g = &grammar{
 		},
 		{
 			name: "_",
-			pos:  position{line: 400, col: 1, offset: 9852},
+			pos:  position{line: 401, col: 1, offset: 9927},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 400, col: 5, offset: 9858},
+				pos: position{line: 401, col: 5, offset: 9933},
 				expr: &choiceExpr{
-					pos: position{line: 400, col: 7, offset: 9860},
+					pos: position{line: 401, col: 7, offset: 9935},
 					alternatives: []interface{}{
 						&ruleRefExpr{
-							pos:  position{line: 400, col: 7, offset: 9860},
+							pos:  position{line: 401, col: 7, offset: 9935},
 							name: "Whitespace",
 						},
 						&ruleRefExpr{
-							pos:  position{line: 400, col: 20, offset: 9873},
+							pos:  position{line: 401, col: 20, offset: 9948},
 							name: "MultiLineCommentNoLineTerminator",
 						},
 					},
@@ -2374,20 +2389,20 @@ var g = &grammar{
 		},
 		{
 			name: "WS",
-			pos:  position{line: 401, col: 1, offset: 9909},
+			pos:  position{line: 402, col: 1, offset: 9984},
 			expr: &zeroOrMoreExpr{
-				pos: position{line: 401, col: 6, offset: 9916},
+				pos: position{line: 402, col: 6, offset: 9991},
 				expr: &ruleRefExpr{
-					pos:  position{line: 401, col: 6, offset: 9916},
+					pos:  position{line: 402, col: 6, offset: 9991},
 					name: "Whitespace",
 				},
 			},
 		},
 		{
 			name: "Whitespace",
-			pos:  position{line: 403, col: 1, offset: 9929},
+			pos:  position{line: 404, col: 1, offset: 10004},
 			expr: &charClassMatcher{
-				pos:        position{line: 403, col: 14, offset: 9944},
+				pos:        position{line: 404, col: 14, offset: 10019},
 				val:        "[ \\t\\r]",
 				chars:      []rune{' ', '\t', '\r'},
 				ignoreCase: false,
@@ -2396,62 +2411,62 @@ var g = &grammar{
 		},
 		{
 			name: "EOL",
-			pos:  position{line: 404, col: 1, offset: 9952},
+			pos:  position{line: 405, col: 1, offset: 10027},
 			expr: &litMatcher{
-				pos:        position{line: 404, col: 7, offset: 9960},
+				pos:        position{line: 405, col: 7, offset: 10035},
 				val:        "\n",
 				ignoreCase: false,
 			},
 		},
 		{
 			name: "EOS",
-			pos:  position{line: 405, col: 1, offset: 9965},
+			pos:  position{line: 406, col: 1, offset: 10040},
 			expr: &choiceExpr{
-				pos: position{line: 405, col: 7, offset: 9973},
+				pos: position{line: 406, col: 7, offset: 10048},
 				alternatives: []interface{}{
 					&seqExpr{
-						pos: position{line: 405, col: 7, offset: 9973},
+						pos: position{line: 406, col: 7, offset: 10048},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 405, col: 7, offset: 9973},
+								pos:  position{line: 406, col: 7, offset: 10048},
 								name: "__",
 							},
 							&litMatcher{
-								pos:        position{line: 405, col: 10, offset: 9976},
+								pos:        position{line: 406, col: 10, offset: 10051},
 								val:        ";",
 								ignoreCase: false,
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 405, col: 16, offset: 9982},
+						pos: position{line: 406, col: 16, offset: 10057},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 405, col: 16, offset: 9982},
+								pos:  position{line: 406, col: 16, offset: 10057},
 								name: "_",
 							},
 							&zeroOrOneExpr{
-								pos: position{line: 405, col: 18, offset: 9984},
+								pos: position{line: 406, col: 18, offset: 10059},
 								expr: &ruleRefExpr{
-									pos:  position{line: 405, col: 18, offset: 9984},
+									pos:  position{line: 406, col: 18, offset: 10059},
 									name: "SingleLineComment",
 								},
 							},
 							&ruleRefExpr{
-								pos:  position{line: 405, col: 37, offset: 10003},
+								pos:  position{line: 406, col: 37, offset: 10078},
 								name: "EOL",
 							},
 						},
 					},
 					&seqExpr{
-						pos: position{line: 405, col: 43, offset: 10009},
+						pos: position{line: 406, col: 43, offset: 10084},
 						exprs: []interface{}{
 							&ruleRefExpr{
-								pos:  position{line: 405, col: 43, offset: 10009},
+								pos:  position{line: 406, col: 43, offset: 10084},
 								name: "__",
 							},
 							&ruleRefExpr{
-								pos:  position{line: 405, col: 46, offset: 10012},
+								pos:  position{line: 406, col: 46, offset: 10087},
 								name: "EOF",
 							},
 						},
@@ -2461,11 +2476,11 @@ var g = &grammar{
 		},
 		{
 			name: "EOF",
-			pos:  position{line: 407, col: 1, offset: 10017},
+			pos:  position{line: 408, col: 1, offset: 10092},
 			expr: &notExpr{
-				pos: position{line: 407, col: 7, offset: 10025},
+				pos: position{line: 408, col: 7, offset: 10100},
 				expr: &anyMatcher{
-					line: 407, col: 8, offset: 10026,
+					line: 408, col: 8, offset: 10101,
 				},
 			},
 		},
@@ -2694,11 +2709,12 @@ func (p *parser) callonFieldList1() (interface{}, error) {
 	return p.cur.onFieldList1(stack["fields"])
 }
 
-func (c *current) onField1(id, req, typ, name, def interface{}) (interface{}, error) {
+func (c *current) onField1(id, req, typ, name, def, annotations interface{}) (interface{}, error) {
 	f := &Field{
-		ID:   int(id.(int64)),
-		Name: string(name.(Identifier)),
-		Type: typ.(*Type),
+		ID:          int(id.(int64)),
+		Name:        string(name.(Identifier)),
+		Type:        typ.(*Type),
+		Annotations: toAnnotations(annotations),
 	}
 	if req != nil && !req.(bool) {
 		f.Optional = true
@@ -2712,7 +2728,7 @@ func (c *current) onField1(id, req, typ, name, def interface{}) (interface{}, er
 func (p *parser) callonField1() (interface{}, error) {
 	stack := p.vstack[len(p.vstack)-1]
 	_ = stack
-	return p.cur.onField1(stack["id"], stack["req"], stack["typ"], stack["name"], stack["def"])
+	return p.cur.onField1(stack["id"], stack["req"], stack["typ"], stack["name"], stack["def"], stack["annotations"])
 }
 
 func (c *current) onFieldReq1() (interface{}, error) {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -5,16 +5,15 @@
 package parser
 
 import (
-	"bytes"
 	"encoding/json"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 )
 
 func TestServiceParsing(t *testing.T) {
-	parser := &Parser{}
-	thrift, err := parser.Parse(bytes.NewBuffer([]byte(`
+	thrift, err := parse(`
 		include "other.thrift"
 
 		namespace go somepkg
@@ -66,7 +65,7 @@ func TestServiceParsing(t *testing.T) {
 		{
 			1: double dbl = 1.2,
 			2: optional string abc
-		}`)))
+		}`)
 
 	if err != nil {
 		t.Fatalf("Service parsing failed with error %s", err.Error())
@@ -262,8 +261,7 @@ func TestServiceParsing(t *testing.T) {
 }
 
 func TestParseTypeAnnotations(t *testing.T) {
-	parser := &Parser{}
-	thrift, err := parser.Parse(bytes.NewBuffer([]byte(`
+	thrift, err := parse(`
 typedef i64 (
 	ann1 = "a1",
 	ann2  =  "a2",
@@ -273,7 +271,7 @@ typedef i64 (
 typedef list<string> (a1 = "v1") listT (a2="v2")
 typedef map<string,i64> (a1 = "v1") mapT (a2="v2")
 typedef set<string> (a1 = "v1") setT (a2="v2")
-`)))
+`)
 	if err != nil {
 		t.Fatalf("Parse annotations failed: %v", err)
 	}
@@ -326,11 +324,10 @@ typedef set<string> (a1 = "v1") setT (a2="v2")
 }
 
 func TestParseConstant(t *testing.T) {
-	parser := &Parser{}
-	thrift, err := parser.Parse(bytes.NewBuffer([]byte(`
+	thrift, err := parse(`
 		const string C1 = "test"
 		const string C2 = C1
-		`)))
+		`)
 	if err != nil {
 		t.Fatalf("Service parsing failed with error %s", err.Error())
 	}
@@ -370,4 +367,10 @@ func pprint(v interface{}) string {
 		panic(err)
 	}
 	return string(b)
+}
+
+func parse(contents string) (*Thrift, error) {
+	parser := &Parser{}
+	thrift, err := parser.Parse(strings.NewReader(contents))
+	return thrift, err
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -319,7 +319,7 @@ typedef set<string> (a1 = "v1") setT (a2="v2")
 		},
 	}
 	if got := thrift.Typedefs; !reflect.DeepEqual(expected, got) {
-		t.Errorf("Unexpected annotation parsing got\n%s\n instead of\n%v", pprint(got), pprint(thrift))
+		t.Errorf("Unexpected annotation parsing got\n%s\n instead of\n%v", pprint(got), pprint(expected))
 	}
 }
 
@@ -359,7 +359,67 @@ func TestParseEnumAnnotations(t *testing.T) {
 		},
 	}
 	if got := thrift.Enums; !reflect.DeepEqual(expected, got) {
-		t.Errorf("Unexpected annotation parsing got\n%s\n instead of\n%v", pprint(got), pprint(thrift))
+		t.Errorf("Unexpected annotation parsing got\n%s\n instead of\n%v", pprint(got), pprint(expected))
+	}
+}
+
+func TestStructLikeAnnotations(t *testing.T) {
+	thrift, err := parse(`
+		struct S {
+			1: optional i32 f1
+			2: optional string f2
+		} (a1 = "v1")
+		union U {
+			1: optional i32 f1
+			2: optional string f2
+		} (a2 = "v2")
+		exception E {
+			1: optional i32 f1
+			2: optional string f2
+		} (a3 = "v3")
+	`)
+	if err != nil {
+		t.Fatalf("Parse struct like annotations failed: %v", err)
+	}
+
+	expected, _ := parse("")
+	fields := []*Field{
+		&Field{
+			ID:       1,
+			Name:     "f1",
+			Optional: true,
+			Type:     &Type{Name: "i32"},
+		},
+		&Field{
+			ID:       2,
+			Name:     "f2",
+			Optional: true,
+			Type:     &Type{Name: "string"},
+		},
+	}
+	expected.Structs = map[string]*Struct{
+		"S": &Struct{
+			Name:        "S",
+			Fields:      fields,
+			Annotations: []*Annotation{{"a1", "v1"}},
+		},
+	}
+	expected.Unions = map[string]*Struct{
+		"U": &Struct{
+			Name:        "U",
+			Fields:      fields,
+			Annotations: []*Annotation{{"a2", "v2"}},
+		},
+	}
+	expected.Exceptions = map[string]*Struct{
+		"E": &Struct{
+			Name:        "E",
+			Fields:      fields,
+			Annotations: []*Annotation{{"a3", "v3"}},
+		},
+	}
+	if !reflect.DeepEqual(expected, thrift) {
+		t.Errorf("Unexpected annotation parsing got\n%s\n instead of\n%v", pprint(thrift), pprint(expected))
 	}
 }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -423,6 +423,40 @@ func TestStructLikeAnnotations(t *testing.T) {
 	}
 }
 
+func TestParseServiceAnnotations(t *testing.T) {
+	thrift, err := parse(`
+		service S {
+			void foo(1: i32 f1) (a1="v1")
+		} (a2 = "v2")
+	`)
+	if err != nil {
+		t.Fatalf("Parse service annotations failed: %v", err)
+	}
+
+	expected := map[string]*Service{
+		"S": &Service{
+			Name: "S",
+			Methods: map[string]*Method{
+				"foo": &Method{
+					Name: "foo",
+					Arguments: []*Field{
+						&Field{
+							ID:   1,
+							Name: "f1",
+							Type: &Type{Name: "i32"},
+						},
+					},
+					Annotations: []*Annotation{{"a1", "v1"}},
+				},
+			},
+			Annotations: []*Annotation{{"a2", "v2"}},
+		},
+	}
+	if got := thrift.Services; !reflect.DeepEqual(expected, got) {
+		t.Errorf("Unexpected annotation parsing got\n%s\n instead of\n%v", pprint(got), pprint(expected))
+	}
+}
+
 func TestParseConstant(t *testing.T) {
 	thrift, err := parse(`
 		const string C1 = "test"

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -363,7 +363,37 @@ func TestParseEnumAnnotations(t *testing.T) {
 	}
 }
 
-func TestStructLikeAnnotations(t *testing.T) {
+func TestParseFieldAnnotations(t *testing.T) {
+	thrift, err := parse(`
+		struct S {
+			1: optional i32 f1 (a1 = "v1")
+		}
+	`)
+	if err != nil {
+		t.Fatalf("Parse struct like annotations failed: %v", err)
+	}
+
+	expected := map[string]*Struct{
+		"S": &Struct{
+			Name: "S",
+			Fields: []*Field{
+				&Field{
+					ID:          1,
+					Name:        "f1",
+					Optional:    true,
+					Type:        &Type{Name: "i32"},
+					Annotations: []*Annotation{{"a1", "v1"}},
+				},
+			},
+		},
+	}
+
+	if got := thrift.Structs; !reflect.DeepEqual(expected, got) {
+		t.Errorf("Unexpected annotation parsing got\n%s\n instead of\n%v", pprint(got), pprint(expected))
+	}
+}
+
+func TestParseStructLikeAnnotations(t *testing.T) {
 	thrift, err := parse(`
 		struct S {
 			1: optional i32 f1

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -323,6 +323,46 @@ typedef set<string> (a1 = "v1") setT (a2="v2")
 	}
 }
 
+func TestParseEnumAnnotations(t *testing.T) {
+	thrift, err := parse(`
+		enum E {
+			ONE (a1="v1"),
+			TWO = 2 (a2 = "v2"),
+			THREE (a3 = "v3")
+		} (a4 = "v4")
+	`)
+	if err != nil {
+		t.Fatalf("Parse enum annotations failed: %v", err)
+	}
+
+	expected := map[string]*Enum{
+		"E": &Enum{
+			Name: "E",
+			Values: map[string]*EnumValue{
+				"ONE": &EnumValue{
+					Name:        "ONE",
+					Value:       0,
+					Annotations: []*Annotation{{"a1", "v1"}},
+				},
+				"TWO": &EnumValue{
+					Name:        "TWO",
+					Value:       2,
+					Annotations: []*Annotation{{"a2", "v2"}},
+				},
+				"THREE": &EnumValue{
+					Name:        "THREE",
+					Value:       3,
+					Annotations: []*Annotation{{"a3", "v3"}},
+				},
+			},
+			Annotations: []*Annotation{{"a4", "v4"}},
+		},
+	}
+	if got := thrift.Enums; !reflect.DeepEqual(expected, got) {
+		t.Errorf("Unexpected annotation parsing got\n%s\n instead of\n%v", pprint(got), pprint(thrift))
+	}
+}
+
 func TestParseConstant(t *testing.T) {
 	thrift, err := parse(`
 		const string C1 = "test"

--- a/parser/types.go
+++ b/parser/types.go
@@ -53,18 +53,20 @@ type Struct struct {
 }
 
 type Method struct {
-	Comment    string
-	Name       string
-	Oneway     bool
-	ReturnType *Type
-	Arguments  []*Field
-	Exceptions []*Field
+	Comment     string
+	Name        string
+	Oneway      bool
+	ReturnType  *Type
+	Arguments   []*Field
+	Exceptions  []*Field
+	Annotations []*Annotation
 }
 
 type Service struct {
-	Name    string
-	Extends string
-	Methods map[string]*Method
+	Name        string
+	Extends     string
+	Methods     map[string]*Method
+	Annotations []*Annotation
 }
 
 type Thrift struct {

--- a/parser/types.go
+++ b/parser/types.go
@@ -7,9 +7,17 @@ package parser
 import "fmt"
 
 type Type struct {
-	Name      string
-	KeyType   *Type // If map
-	ValueType *Type // If map, list, or set
+	Name        string
+	KeyType     *Type // If map
+	ValueType   *Type // If map, list, or set
+	Annotations []*Annotation
+}
+
+type Typedef struct {
+	*Type
+
+	Alias       string
+	Annotations []*Annotation
 }
 
 type EnumValue struct {
@@ -58,7 +66,7 @@ type Service struct {
 
 type Thrift struct {
 	Includes   map[string]string // name -> unique identifier (absolute path generally)
-	Typedefs   map[string]*Type
+	Typedefs   map[string]*Typedef
 	Namespaces map[string]string
 	Constants  map[string]*Constant
 	Enums      map[string]*Enum
@@ -72,6 +80,11 @@ type Identifier string
 
 type KeyValue struct {
 	Key, Value interface{}
+}
+
+type Annotation struct {
+	Name  string
+	Value string
 }
 
 func (t *Type) String() string {

--- a/parser/types.go
+++ b/parser/types.go
@@ -47,8 +47,9 @@ type Field struct {
 }
 
 type Struct struct {
-	Name   string
-	Fields []*Field
+	Name        string
+	Fields      []*Field
+	Annotations []*Annotation
 }
 
 type Method struct {

--- a/parser/types.go
+++ b/parser/types.go
@@ -39,11 +39,12 @@ type Constant struct {
 }
 
 type Field struct {
-	ID       int
-	Name     string
-	Optional bool
-	Type     *Type
-	Default  interface{}
+	ID          int
+	Name        string
+	Optional    bool
+	Type        *Type
+	Default     interface{}
+	Annotations []*Annotation
 }
 
 type Struct struct {

--- a/parser/types.go
+++ b/parser/types.go
@@ -21,13 +21,15 @@ type Typedef struct {
 }
 
 type EnumValue struct {
-	Name  string
-	Value int
+	Name        string
+	Value       int
+	Annotations []*Annotation
 }
 
 type Enum struct {
-	Name   string
-	Values map[string]*EnumValue
+	Name        string
+	Values      map[string]*EnumValue
+	Annotations []*Annotation
 }
 
 type Constant struct {


### PR DESCRIPTION
This changes the API for `Typedefs` since they are now of type `*Typedef` rather than `*Type`. But to make migration easier, it embeds `*Type`.

@samuel 