### PR TITLE
Add Get.*() methods to structs

### DIFF
--- a/generator/go.go
+++ b/generator/go.go
@@ -18,6 +18,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"text/template"
 
 	"github.com/samuel/go-thrift/parser"
 )
@@ -264,6 +265,54 @@ func (g *GoGenerator) formatField(field *parser.Field) string {
 		camelCase(field.Name), g.formatType(g.pkg, g.thrift, field.Type, opt), field.ID, tags, field.Name, jsonTags)
 }
 
+var getterTmpl = template.Must(template.New("").Parse(`func ({{ .Receiver }} *{{ .Typ }}) Get{{ .Field }}() (val {{ .FieldTyp }}) {
+	if {{ .Receiver }} != nil && {{ .Receiver }}.{{ .Field }} != nil {
+		return {{ if .Ptr }}*{{ end }}{{ .Receiver }}.{{ .Field }}
+	}
+
+{{ if .Zero }}
+	val = {{ .Zero }}
+{{ end }}
+	return
+}
+`))
+
+func (g *GoGenerator) formatFieldGetter(receiver, typ string, field *parser.Field) string {
+	buf := new(bytes.Buffer)
+
+	zero := ""
+	if field.Default != nil {
+		var err error
+		zero, err = g.formatValue(field.Default, field.Type)
+		if err != nil {
+			g.error(err)
+		}
+	}
+
+	isPtr := !(field.Type.Name == "list" || field.Type.Name == "set" || field.Type.Name == "map")
+	if field.Type.Name == "binary" && !*flagGoBinarystring {
+		isPtr = false
+	}
+
+	if err := getterTmpl.Execute(buf, struct {
+		Receiver, Typ   string
+		Field, FieldTyp string
+		Zero            string
+		Ptr             bool
+	}{
+		Receiver: receiver,
+		Typ:      typ,
+		Field:    camelCase(field.Name),
+		FieldTyp: g.formatType(g.pkg, g.thrift, field.Type, toNoPointer),
+		Zero:     zero,
+		Ptr:      isPtr,
+	}); err != nil {
+		g.error(err)
+	}
+
+	return buf.String()
+}
+
 func (g *GoGenerator) formatArguments(arguments []*parser.Field) string {
 	args := make([]string, len(arguments))
 	for i, arg := range arguments {
@@ -432,7 +481,16 @@ func (g *GoGenerator) writeStruct(out io.Writer, st *parser.Struct) error {
 	for _, field := range st.Fields {
 		g.write(out, "\t%s\n", g.formatField(field))
 	}
-	return g.write(out, "}\n")
+	g.write(out, "}\n")
+
+	receiver := strings.ToLower(structName[:1])
+
+	// generate Get methods for all fields
+	for _, field := range st.Fields {
+		g.write(out, "%s\n", g.formatFieldGetter(receiver, structName, field))
+	}
+
+	return g.write(out, "\n")
 }
 
 func (g *GoGenerator) writeException(out io.Writer, ex *parser.Struct) error {

--- a/testfiles/generator/nestedstruct.go
+++ b/testfiles/generator/nestedstruct.go
@@ -12,8 +12,40 @@ type NestedColor struct {
 	Rgb *Rgb `thrift:"1,required" json:"rgb"`
 }
 
+func (n *NestedColor) GetRgb() (val Rgb) {
+	if n != nil && n.Rgb != nil {
+		return *n.Rgb
+	}
+
+	return
+}
+
 type Rgb struct {
 	Red   *int32 `thrift:"1,required" json:"red"`
 	Green *int32 `thrift:"2,required" json:"green"`
 	Blue  *int32 `thrift:"3,required" json:"blue"`
+}
+
+func (r *Rgb) GetRed() (val int32) {
+	if r != nil && r.Red != nil {
+		return *r.Red
+	}
+
+	return
+}
+
+func (r *Rgb) GetGreen() (val int32) {
+	if r != nil && r.Green != nil {
+		return *r.Green
+	}
+
+	return
+}
+
+func (r *Rgb) GetBlue() (val int32) {
+	if r != nil && r.Blue != nil {
+		return *r.Blue
+	}
+
+	return
 }

--- a/testfiles/generator/set.go
+++ b/testfiles/generator/set.go
@@ -13,3 +13,27 @@ type StSet struct {
 	I32Set    map[int32]struct{}  `thrift:"2,required" json:"i32_set"`
 	BinarySet map[string]struct{} `thrift:"3,required" json:"binary_set"`
 }
+
+func (s *StSet) GetStringSet() (val map[string]struct{}) {
+	if s != nil && s.StringSet != nil {
+		return s.StringSet
+	}
+
+	return
+}
+
+func (s *StSet) GetI32Set() (val map[int32]struct{}) {
+	if s != nil && s.I32Set != nil {
+		return s.I32Set
+	}
+
+	return
+}
+
+func (s *StSet) GetBinarySet() (val map[string]struct{}) {
+	if s != nil && s.BinarySet != nil {
+		return s.BinarySet
+	}
+
+	return
+}

--- a/testfiles/generator/typedefs.go
+++ b/testfiles/generator/typedefs.go
@@ -17,3 +17,27 @@ type St struct {
 	S *String `thrift:"2,required" json:"s"`
 	I *Int32  `thrift:"3,required" json:"i"`
 }
+
+func (s *St) GetB() (val Binary) {
+	if s != nil && s.B != nil {
+		return *s.B
+	}
+
+	return
+}
+
+func (s *St) GetS() (val String) {
+	if s != nil && s.S != nil {
+		return *s.S
+	}
+
+	return
+}
+
+func (s *St) GetI() (val Int32) {
+	if s != nil && s.I != nil {
+		return *s.I
+	}
+
+	return
+}


### PR DESCRIPTION
Makes working with pointer objects simpler. The Receiver == nil check, in particular, supports chaining on possibly missing fields.