### PR TITLE
struct & const fixes

### DIFF
--- a/generator/go.go
+++ b/generator/go.go
@@ -660,10 +660,11 @@ func (g *GoGenerator) generateSingle(out io.Writer, thriftPath string, thrift *p
 				g.error(err)
 			}
 
-			if c.Type.Name == "list" || c.Type.Name == "map" || c.Type.Name == "set" {
-				g.write(out, "var ")
-			} else {
+			switch c.Value.(type) {
+			case string, int, int64, float64:
 				g.write(out, "const ")
+			default:
+				g.write(out, "var ")
 			}
 			g.write(out, "\t%s = %+v\n", camelCase(c.Name), v)
 		}

--- a/generator/go.go
+++ b/generator/go.go
@@ -205,21 +205,21 @@ func (g *GoGenerator) formatType(pkg string, thrift *parser.Thrift, typ *parser.
 		if pkg != g.pkg {
 			name = pkg + "." + name
 		}
-		return "*" + name
+		return ptr + name
 	}
 	if e := thrift.Exceptions[typ.Name]; e != nil {
 		name := e.Name
 		if pkg != g.pkg {
 			name = pkg + "." + name
 		}
-		return "*" + name
+		return ptr + name
 	}
 	if u := thrift.Unions[typ.Name]; u != nil {
 		name := u.Name
 		if pkg != g.pkg {
 			name = pkg + "." + name
 		}
-		return "*" + name
+		return ptr + name
 	}
 
 	g.error(ErrUnknownType(typ.Name))
@@ -301,7 +301,7 @@ func (g *GoGenerator) formatValue(v interface{}, t *parser.Type) (string, error)
 		return strconv.FormatFloat(v2, 'f', -1, 64), nil
 	case []interface{}:
 		buf := &bytes.Buffer{}
-		buf.WriteString(g.formatType(g.pkg, g.thrift, t, 0))
+		buf.WriteString(g.formatType(g.pkg, g.thrift, t, toNoPointer))
 		buf.WriteString("{\n")
 		for _, v := range v2 {
 			buf.WriteString("\t\t")
@@ -319,7 +319,7 @@ func (g *GoGenerator) formatValue(v interface{}, t *parser.Type) (string, error)
 		return buf.String(), nil
 	case []parser.KeyValue:
 		buf := &bytes.Buffer{}
-		buf.WriteString(g.formatType(g.pkg, g.thrift, t, 0))
+		buf.WriteString(g.formatType(g.pkg, g.thrift, t, toNoPointer))
 		buf.WriteString("{\n")
 		for _, kv := range v2 {
 			buf.WriteString("\t\t")


### PR DESCRIPTION
I was getting some output that looked like

```go
const Foo = *Bar{
  Baz: 1
}
```

The first commit fixes `const` to `var` and the second commit removes the `*`. The second commit seems to have some cascading impact to struct fields, fixing cases where there were double-optionals, like pointers to slices.