### PR TITLE
Fix return type typo for oneway method

### DIFF
--- a/generator/go.go
+++ b/generator/go.go
@@ -565,7 +565,7 @@ func (g *GoGenerator) writeService(out io.Writer, svc *parser.Service) error {
 	for _, k := range methodNames {
 		method := svc.Methods[k]
 		methodName := camelCase(method.Name)
-		returnType := "err error"
+		returnType := "(err error)"
 		if !method.Oneway {
 			returnType = g.formatReturnType(method.ReturnType, true)
 		}


### PR DESCRIPTION
When a function in thrift is declared as oneway, the go code generated will have the default return type 'err error', it should be wrapped with bracket.