### PR TITLE
Making typedefed maps and slices passing by value.

### DIFF
--- a/generator/go.go
+++ b/generator/go.go
@@ -198,7 +198,12 @@ func (g *GoGenerator) formatType(pkg string, thrift *parser.Thrift, typ *parser.
 		if pkg != g.pkg {
 			name = pkg + "." + name
 		}
-		return ptr + name
+		// for reference types like map or list we don't use pointers
+		if t.RefType() {
+			return name
+		} else {
+			return ptr + name
+		}
 	}
 	if e := thrift.Enums[typ.Name]; e != nil {
 		name := e.Name

--- a/parser/types.go
+++ b/parser/types.go
@@ -104,3 +104,8 @@ func (t *Type) String() string {
 	}
 	return t.Name
 }
+
+// return true for reference types (map, list, set)
+func (t *Type) RefType() bool {
+	return t.KeyType != nil || t.ValueType != nil
+}

--- a/testfiles/generator/rpc_stub.go
+++ b/testfiles/generator/rpc_stub.go
@@ -1,0 +1,5 @@
+package gentest
+
+type RPCClient interface {
+	Call(method string, request interface{}, response interface{}) error
+}

--- a/testfiles/generator/typedefs.thrift
+++ b/testfiles/generator/typedefs.thrift
@@ -3,9 +3,20 @@ namespace go gentest
 typedef binary Binary
 typedef string String
 typedef i32    Int32
+typedef map<i32,string> Map1
+typedef map<i32,Map1> Map2
 
 struct St {
 	1: Binary b,
 	2: String s,
 	3: Int32 i
 }
+
+service Svc {
+  Binary ping(),
+  Map2 call(
+    1:string name,
+    2:Map1 map1,
+    3:Binary data)
+}
+


### PR DESCRIPTION
Current implementation generates non-compilable code
if typedef defined.

example:

type Map1 map[int32]string

this would generate different access code for parameters
and return values. Return values will be return by value,
but argumets of functions and structure fields will be pointers.

Good example of incompatible thrift is:
https://github.com/osquery/osquery-python/blob/master/osquery.thrift

Trying to generate and compile produce:
osquery/extensions/osquery.go:191: cannot use val (type
InternalExtensionList) as type *InternalExtensionList in assignment
osquery/extensions/osquery.go:203: cannot use val (type
InternalOptionList) as type *InternalOptionList in assignment
osquery/extensions/osquery.go:287: cannot use res.Value (type
*InternalExtensionList) as type InternalExtensionList in assignment
osquery/extensions/osquery.go:309: cannot use res.Value (type
*InternalOptionList) as type InternalOptionList in assignment